### PR TITLE
add --conf option to specify conf file path

### DIFF
--- a/config.go
+++ b/config.go
@@ -23,8 +23,8 @@ func loadHostID(root string) (string, error) {
 }
 
 // LoadApikeyFromConfig gets mackerel.io apikey from mackerel-agent.conf if it's installed mackerel-agent on localhost
-func LoadApikeyFromConfig() string {
-	conf, err := config.LoadConfig(config.DefaultConfig.Conffile)
+func LoadApikeyFromConfig(conffile string) string {
+	conf, err := config.LoadConfig(conffile)
 	if err != nil {
 		return ""
 	}
@@ -32,17 +32,17 @@ func LoadApikeyFromConfig() string {
 }
 
 // LoadApikeyFromEnvOrConfig is similar to LoadApikeyFromConfig. return MACKEREL_APIKEY environment value if defined MACKEREL_APIKEY
-func LoadApikeyFromEnvOrConfig() string {
+func LoadApikeyFromEnvOrConfig(conffile string) string {
 	if apiKey := os.Getenv("MACKEREL_APIKEY"); apiKey != "" {
 		return apiKey
 	}
-	key := LoadApikeyFromConfig()
+	key := LoadApikeyFromConfig(conffile)
 	return key
 }
 
 // LoadHostIDFromConfig gets localhost's hostID from conf.Root (ex. /var/lib/mackerel/id) if it's installed mackerel-agent on localhost
-func LoadHostIDFromConfig() string {
-	conf, err := config.LoadConfig(config.DefaultConfig.Conffile)
+func LoadHostIDFromConfig(conffile string) string {
+	conf, err := config.LoadConfig(conffile)
 	if err != nil {
 		return ""
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -1,19 +1,15 @@
 package main
 
-import (
-	"os"
-
-	"github.com/mackerelio/mackerel-agent/config"
-)
+import "os"
 
 import (
 	"testing"
 )
 
 func TestLoadApikeyFromConfig(t *testing.T) {
-	config.DefaultConfig.Conffile = "test/mackerel-agent.conf"
+	conffile := "test/mackerel-agent.conf"
 
-	apiKey := LoadApikeyFromConfig()
+	apiKey := LoadApikeyFromConfig(conffile)
 
 	if apiKey != "123456ABCD" {
 		t.Error("should be 123456ABCD")
@@ -23,9 +19,9 @@ func TestLoadApikeyFromConfig(t *testing.T) {
 func TestLoadApikeyFromConfigOrEnv(t *testing.T) {
 	os.Setenv("MACKEREL_APIKEY", "")
 
-	config.DefaultConfig.Conffile = "test/mackerel-agent.conf"
+	conffile := "test/mackerel-agent.conf"
 
-	apiKey := LoadApikeyFromEnvOrConfig()
+	apiKey := LoadApikeyFromEnvOrConfig(conffile)
 
 	if apiKey != "123456ABCD" {
 		t.Error("should be 123456ABCD")
@@ -33,7 +29,7 @@ func TestLoadApikeyFromConfigOrEnv(t *testing.T) {
 
 	os.Setenv("MACKEREL_APIKEY", "ENV123456ABCD")
 
-	apiKey = LoadApikeyFromEnvOrConfig()
+	apiKey = LoadApikeyFromEnvOrConfig(conffile)
 
 	if apiKey != "ENV123456ABCD" {
 		t.Error("should be ENV123456ABCD")
@@ -43,9 +39,9 @@ func TestLoadApikeyFromConfigOrEnv(t *testing.T) {
 }
 
 func TestLoadHostIDFromConfig(t *testing.T) {
-	config.DefaultConfig.Conffile = "test/mackerel-agent.conf"
+	conffile := "test/mackerel-agent.conf"
 
-	hostID := LoadHostIDFromConfig()
+	hostID := LoadHostIDFromConfig(conffile)
 
 	if hostID == "" {
 		t.Error("should not be empty")

--- a/mkr.go
+++ b/mkr.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 
 	"github.com/codegangsta/cli"
+	"github.com/mackerelio/mackerel-agent/config"
 )
 
 func main() {
@@ -14,6 +15,13 @@ func main() {
 	app.Usage = "A CLI tool for mackerel.io"
 	app.Author = "Hatena Co., Ltd."
 	app.Commands = Commands
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "conf",
+			Value: config.DefaultConfig.Conffile,
+			Usage: "Config file path",
+		},
+	}
 
 	cpu := runtime.NumCPU()
 	runtime.GOMAXPROCS(cpu)


### PR DESCRIPTION
I want to specify conf file path using command line option.

This patch adds a `--conf` option like bellow,

```
$ mkr --conf=/usr/loca/etc/mackerel-agent.conf hosts
```

thank you for your review.