### PR TITLE
delete default argument for retire command

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -447,11 +447,8 @@ func doRetire(c *cli.Context) {
 	argHostIDs := c.Args()
 
 	if len(argHostIDs) < 1 {
-		argHostIDs = make([]string, 1)
-		if argHostIDs[0] = LoadHostIDFromConfig(conffile); argHostIDs[0] == "" {
-			cli.ShowCommandHelp(c, "retire")
-			os.Exit(1)
-		}
+		cli.ShowCommandHelp(c, "retire")
+		os.Exit(1)
 	}
 
 	client := newMackerel(conffile)


### PR DESCRIPTION
## problem

Someday, I missed type `mkr retire` without host id argument.
Another day I ran wrong shell script for batch retire, host id is null.
then my PRIMARY host had retired...

`retire` action cannot be rollback.
my metric data is completely lost.


## solution

* delete default host id argument
* `mkr retire` requires at least 1 argument now

How about this idea?