### PR TITLE
Fix update command as firstaid

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -354,10 +354,14 @@ func doUpdate(c *cli.Context) {
 			if needUpdateHost {
 				host, err := client.FindHost(hostID)
 				logger.DieIf(err)
+				meta := host.Meta
+				if optName == "" {
+					optName = host.Name
+				}
 				_, err = client.UpdateHost(hostID, &mkr.UpdateHostParam{
 					Name:          optName,
 					RoleFullnames: optRoleFullnames,
-					Meta:          host.Meta,
+					Meta:          meta,
 				})
 				logger.DieIf(err)
 			}

--- a/commands.go
+++ b/commands.go
@@ -352,9 +352,12 @@ func doUpdate(c *cli.Context) {
 			}
 
 			if needUpdateHost {
-				_, err := client.UpdateHost(hostID, &mkr.UpdateHostParam{
+				host, err := client.FindHost(hostID)
+				logger.DieIf(err)
+				_, err = client.UpdateHost(hostID, &mkr.UpdateHostParam{
 					Name:          optName,
 					RoleFullnames: optRoleFullnames,
+					Meta:          host.Meta,
 				})
 				logger.DieIf(err)
 			}


### PR DESCRIPTION
## Overview

* this patch is a workaround fix.
* Please let us know what you think

## Problem

* `update` command overrides host meta data using empty data.
* `update`command with `-R` option requires name.

## Solution

* fetch host data before execute update for autofilling lack data.

