### PR TITLE
mkr update command bug about overwriting hostname

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -369,11 +369,14 @@ func doUpdate(c *cli.Context) {
 				host, err := client.FindHost(hostID)
 				logger.DieIf(err)
 				meta := host.Meta
+				name := ""
 				if optName == "" {
-					optName = host.Name
+					name = host.Name
+				} else {
+					name = optName
 				}
 				_, err = client.UpdateHost(hostID, &mkr.UpdateHostParam{
-					Name:          optName,
+					Name:          name,
 					RoleFullnames: optRoleFullnames,
 					Meta:          meta,
 				})


### PR DESCRIPTION
Fix update command bug that the 'mkr update' overwrite each host's 'name' as the same 'name' value when '-n' option value is empty and multiple hostIds are passed