### PR TITLE
Suppress to display empty fields when mkr monitors diff

### DIFF
--- a/monitors.go
+++ b/monitors.go
@@ -133,21 +133,43 @@ func doMonitorsPull(c *cli.Context) {
 	logger.Log("info", fmt.Sprintf("Monitor rules are saved to '%s' (%d rules).", filePath, len(monitors)))
 }
 
+func isEmpty(a interface{}) bool {
+	switch a.(type) {
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		if a.(uint64) == 0 {
+			return true
+		}
+	case float32, float64:
+		if a.(float64) == 0.0 {
+			return true
+		}
+	case string:
+		if a.(string) == "" {
+			return true
+		}
+	}
+	return false
+}
+
 func appendDiff(src []string, name string, a interface{}, b interface{}) []string {
-	diff := []string{}
+	diff := src
 	aType := reflect.TypeOf(a).String()
 	format := "\"%s\""
+	isAEmpty := isEmpty(a)
+	isBEmpty := isEmpty(b)
 	switch aType {
 	case "uint64":
 		format = "%d"
 	case "float64":
 		format = "%f"
 	}
-	if b != nil && a != b {
-		diff = append(src, fmt.Sprintf("-  \"%s\": "+format+",", name, a))
-		diff = append(diff, fmt.Sprintf("+  \"%s\": "+format+",", name, b))
-	} else {
-		diff = append(src, fmt.Sprintf("   \"%s\": "+format+",", name, a))
+	if isAEmpty == false || isBEmpty == false {
+		if a != b {
+			diff = append(diff, fmt.Sprintf("-  \"%s\": "+format+",", name, a))
+			diff = append(diff, fmt.Sprintf("+  \"%s\": "+format+",", name, b))
+		} else {
+			diff = append(diff, fmt.Sprintf("   \"%s\": "+format+",", name, a))
+		}
 	}
 	return diff
 }
@@ -201,6 +223,9 @@ func diffMonitor(a *mkr.Monitor, b *mkr.Monitor) string {
 				diffNum++
 			}
 		} else {
+			if len(fA.Interface().([]string)) == 0 && len(fB.Interface().([]string)) == 0 {
+				continue
+			}
 			name := strings.Replace(sAType.Field(i).Tag.Get("json"), ",omitempty", "", 1)
 			diff = append(diff, fmt.Sprintf("    \"%s\": [", name))
 			sortA := fA.Interface().([]string)

--- a/monitors.go
+++ b/monitors.go
@@ -135,16 +135,20 @@ func doMonitorsPull(c *cli.Context) {
 
 func isEmpty(a interface{}) bool {
 	switch a.(type) {
-	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-		if a.(uint64) == 0 {
+	case int, int8, int16, int32, int64:
+		if reflect.ValueOf(a).Int() == 0 {
+			return true
+		}
+	case uint, uint8, uint16, uint32, uint64:
+		if reflect.ValueOf(a).Uint() == 0 {
 			return true
 		}
 	case float32, float64:
-		if a.(float64) == 0.0 {
+		if reflect.ValueOf(a).Float() == 0.0 {
 			return true
 		}
 	case string:
-		if a.(string) == "" {
+		if reflect.ValueOf(a).String() == "" {
 			return true
 		}
 	}

--- a/monitors_test.go
+++ b/monitors_test.go
@@ -38,7 +38,7 @@ func TestDiffMonitors(t *testing.T) {
 
 	ret := diffMonitor(a, b)
 
-	zz := []string{
+	correct := strings.Join([]string{
 		"  {",
 		"   \"name\": \"foo\",",
 		"   \"type\": \"external\",",
@@ -47,10 +47,10 @@ func TestDiffMonitors(t *testing.T) {
 		"-  \"responseTimeCritical\": 1000.000000,",
 		"+  \"responseTimeCritical\": 0.000000,",
 		"  },",
-	}
+	}, "\n")
 
-	if ret != strings.Join(zz, "\n") {
-		t.Errorf("should validate the rule: %s\n%s", ret, strings.Join(zz, "\n"))
+	if ret != correct {
+		t.Errorf("should validate the rule: %s\nbut result: %s", correct, ret)
 	}
 
 }

--- a/monitors_test.go
+++ b/monitors_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	mkr "github.com/mackerelio/mackerel-client-go"
@@ -27,6 +28,29 @@ func TestValidateRoles(t *testing.T) {
 	ret, err := validateRules([](*mkr.Monitor){a}, "test monitor")
 	if ret != true {
 		t.Errorf("should validate the rule: %s", err.Error())
+	}
+
+}
+
+func TestDiffMonitors(t *testing.T) {
+	a := &mkr.Monitor{ID: "12345", Name: "foo", Type: "external", URL: "http://example.com", Service: "bar", ResponseTimeCritical: 1000}
+	b := &mkr.Monitor{ID: "12345", Name: "foo", Type: "external", URL: "http://example.com", Service: "bar"}
+
+	ret := diffMonitor(a, b)
+
+	zz := []string{
+		"  {",
+		"   \"name\": \"foo\",",
+		"   \"type\": \"external\",",
+		"   \"url\": \"http://example.com\",",
+		"   \"service\": \"bar\",",
+		"-  \"responseTimeCritical\": 1000.000000,",
+		"+  \"responseTimeCritical\": 0.000000,",
+		"  },",
+	}
+
+	if ret != strings.Join(zz, "\n") {
+		t.Errorf("should validate the rule: %s\n%s", ret, strings.Join(zz, "\n"))
 	}
 
 }


### PR DESCRIPTION
This pull request suppress to display empty fields.

For example, `"scopes"` field are shown as follows, but this field should not be outputted.

```
# mkr monitors diff
Summary: 1 modify, 0 append, 0 remove

  {
   "name": "blog.stanaka.org",
   "type": "external",
   "metric": "",
   "operator": "",
   "warning": 0.000000,
   "critical": 0.000000,
   "duration": 0,
   "url": "http://blog.stanaka.org",
    "scopes": [
    ],
   "service": "stanaka",
   "maxCheckAttempts": 1.000000,
    "excludeScopes": [
    ],
-  "responseTimeCritical": 10000.000000,
+  "responseTimeCritical": 0.000000,
-  "responseTimeWarning": 5000.000000,
+  "responseTimeWarning": 0.000000,
-  "responseTimeDuration": 3.000000,
+  "responseTimeDuration": 0.000000,
  },
```