### PR TITLE
Release version 0.7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ deploy:
   api_key:
     secure: Rzt3UJJnYi51r53yVpvg+5McqPEV+qLig6VPW+2V9hrSzd+25bJtoOesuWdKneHeeEkTivTzH3SillWdEDFlQdr+HBh/Th3n0M9GHKYMtI+b9z5BeqZWqJ8lSCICdTRmOwarUWSIV33JwgQ3og/bxVEGTRmqMpYMrPHWSBWGGeQ=
   file:
-    - "/home/travis/rpmbuild/RPMS/noarch/mkr-0.7.0-1.noarch.rpm"
-    - "/home/travis/gopath/src/github.com/mackerelio/mkr/packaging/mkr_0.7.0-1_all.deb"
+    - "/home/travis/rpmbuild/RPMS/noarch/mkr-0.7.1-1.noarch.rpm"
+    - "/home/travis/gopath/src/github.com/mackerelio/mkr/packaging/mkr_0.7.1-1_all.deb"
     - "/home/travis/gopath/src/github.com/mackerelio/mkr/snapshot/mkr_linux_amd64"
     - "/home/travis/gopath/src/github.com/mackerelio/mkr/snapshot/mkr_linux_386"
     - "/home/travis/gopath/src/github.com/mackerelio/mkr/snapshot/mkr_darwin_amd64"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.1 (2015-11-12)
+
+
+
 ## 0.7.0 (2015-10-26)
 
 * append newline to the end of monitors.json #23 (Songmu)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 0.7.1 (2015-11-12)
 
-
+* support `notificationIntervai` field in monitors (stanaka)
+* [bug] fix json parameter s/hostID/hostId/g (Songmu)
 
 ## 0.7.0 (2015-10-26)
 
@@ -10,10 +11,9 @@
 * fix printMonitor #24 (Songmu)
 * fix diff output between slices #25 (Songmu)
 
-
 ## 0.6.0 (2015-10-15)
 
-* Fix update command bug about overwriting hostname #17 (y_uuki) 
+* Fix update command bug about overwriting hostname #17 (y_uuki)
 * Stop the parallel request sending temporarily #18 (y_uuki)
 * Suppress to display empty fields when mkr monitors diff #20 (by stanaka)
 

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,8 @@
+mkr (0.7.1-1) stable; urgency=low
+
+
+ -- Songmu <y.songmu@gmail.com>  Thu, 12 Nov 2015 12:15:11 +0900
+
 mkr (0.7.0-1) stable; urgency=low
 
   * append newline to the end of monitors.json (by Songmu)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,5 +1,9 @@
 mkr (0.7.1-1) stable; urgency=low
 
+  * support `notificationIntervai` field in monitors (by stanaka)
+    <https://github.com/mackerelio/mackerel-client-go/pull/9>
+  * [bug] fix json parameter s/hostID/hostId/g (by Songmu)
+    <https://github.com/mackerelio/mackerel-client-go/pull/10>
 
  -- Songmu <y.songmu@gmail.com>  Thu, 12 Nov 2015 12:15:11 +0900
 

--- a/packaging/rpm/mkr.spec
+++ b/packaging/rpm/mkr.spec
@@ -42,6 +42,8 @@ rm -f %{buildroot}%{_bindir}/${name}
 %{_localbindir}/%{name}
 
 %changelog
+* Thu Nov 12 2015 <y.songmu@gmail.com> - 0.7.1-1
+
 * Mon Oct 26 2015 <daiksy@hatena.ne.jp> - 0.7.0-1
 - append newline to the end of monitors.json (by Songmu)
 - fix printMonitor (by Songmu)

--- a/packaging/rpm/mkr.spec
+++ b/packaging/rpm/mkr.spec
@@ -5,7 +5,7 @@
 %define _localbindir /usr/local/bin
 
 Name:      mkr
-Version:   0.7.0
+Version:   0.7.1
 Release:   1
 License:   Apache-2.0
 Summary:   macekrel.io api client tool

--- a/packaging/rpm/mkr.spec
+++ b/packaging/rpm/mkr.spec
@@ -43,6 +43,8 @@ rm -f %{buildroot}%{_bindir}/${name}
 
 %changelog
 * Thu Nov 12 2015 <y.songmu@gmail.com> - 0.7.1-1
+- support `notificationIntervai` field in monitors (stanaka)
+- [bug] fix json parameter s/hostID/hostId/g (Songmu)
 
 * Mon Oct 26 2015 <daiksy@hatena.ne.jp> - 0.7.0-1
 - append newline to the end of monitors.json (by Songmu)


### PR DESCRIPTION
update https://github.com/mackerelio/mackerel-client-go dependency.

- support `notificationIntervai` field in monitors (stanaka)
- [bug] fix json parameter s/hostID/hostId/g (Songmu)