### PR TITLE
Release version 0.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ deploy:
   api_key:
     secure: Rzt3UJJnYi51r53yVpvg+5McqPEV+qLig6VPW+2V9hrSzd+25bJtoOesuWdKneHeeEkTivTzH3SillWdEDFlQdr+HBh/Th3n0M9GHKYMtI+b9z5BeqZWqJ8lSCICdTRmOwarUWSIV33JwgQ3og/bxVEGTRmqMpYMrPHWSBWGGeQ=
   file:
-    - "/home/travis/rpmbuild/RPMS/noarch/mkr-0.7.1-1.noarch.rpm"
-    - "/home/travis/gopath/src/github.com/mackerelio/mkr/packaging/mkr_0.7.1-1_all.deb"
+    - "/home/travis/rpmbuild/RPMS/noarch/mkr-0.8.0-1.noarch.rpm"
+    - "/home/travis/gopath/src/github.com/mackerelio/mkr/packaging/mkr_0.8.0-1_all.deb"
     - "/home/travis/gopath/src/github.com/mackerelio/mkr/snapshot/mkr_linux_amd64"
     - "/home/travis/gopath/src/github.com/mackerelio/mkr/snapshot/mkr_linux_386"
     - "/home/travis/gopath/src/github.com/mackerelio/mkr/snapshot/mkr_darwin_amd64"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.8.0 (2016-01-06)
+
+* support alerts subcommand #31 (stanaka)
+* Fix README example about mkr throw #32 (yuuki1)
+* Build with Go 1.5 #33 (itchyny)
+* Fixed the english used in the command descriptions #35 (stefafafan)
+
+
 ## 0.7.1 (2015-11-12)
 
 * support `notificationIntervai` field in monitors (stanaka)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,16 @@
+mkr (0.8.0-1) stable; urgency=low
+
+  * support alerts subcommand (by stanaka)
+    <https://github.com/mackerelio/mkr/pull/31>
+  * Fix README example about mkr throw (by yuuki1)
+    <https://github.com/mackerelio/mkr/pull/32>
+  * Build with Go 1.5 (by itchyny)
+    <https://github.com/mackerelio/mkr/pull/33>
+  * Fixed the english used in the command descriptions (by stefafafan)
+    <https://github.com/mackerelio/mkr/pull/35>
+
+ -- Songmu <y.songmu@gmail.com>  Wed, 06 Jan 2016 20:38:20 +0900
+
 mkr (0.7.1-1) stable; urgency=low
 
   * support `notificationIntervai` field in monitors (by stanaka)

--- a/packaging/rpm/mkr.spec
+++ b/packaging/rpm/mkr.spec
@@ -5,7 +5,7 @@
 %define _localbindir /usr/local/bin
 
 Name:      mkr
-Version:   0.7.1
+Version:   0.8.0
 Release:   1
 License:   Apache-2.0
 Summary:   macekrel.io api client tool

--- a/packaging/rpm/mkr.spec
+++ b/packaging/rpm/mkr.spec
@@ -42,6 +42,12 @@ rm -f %{buildroot}%{_bindir}/${name}
 %{_localbindir}/%{name}
 
 %changelog
+* Wed Jan 06 2016 <y.songmu@gmail.com> - 0.8.0-1
+- support alerts subcommand (by stanaka)
+- Fix README example about mkr throw (by yuuki1)
+- Build with Go 1.5 (by itchyny)
+- Fixed the english used in the command descriptions (by stefafafan)
+
 * Thu Nov 12 2015 <y.songmu@gmail.com> - 0.7.1-1
 - support `notificationIntervai` field in monitors (stanaka)
 - [bug] fix json parameter s/hostID/hostId/g (Songmu)


### PR DESCRIPTION
- support alerts subcommand #31
- Fix README example about mkr throw #32
- Build with Go 1.5 #33
- Fixed the english used in the command descriptions #35