### PR TITLE
fix handling host-status option

### DIFF
--- a/alerts.go
+++ b/alerts.go
@@ -194,7 +194,7 @@ func doAlertsRetrieve(c *cli.Context) {
 func doAlertsList(c *cli.Context) {
 	conffile := c.GlobalString("conf")
 	filterServices := c.StringSlice("service")
-	filterStatuses := c.StringSlice("status")
+	filterStatuses := c.StringSlice("host-status")
 	client := newMackerel(conffile)
 
 	alerts, err := client.FindAlerts()


### PR DESCRIPTION
```
% mkr alerts list --host-status working
2Aebsaa 2016-01-07 18:37:34 WARNING  memory% 98.02 > 98.00 db01 working [foo:db]
2AcM2nn 2016-01-07 06:43:01 WARNING  memory% 98.12 > 98.00 db02 working [foo:db]
```