### PR TITLE
replace angle brackets for json

### DIFF
--- a/format.go
+++ b/format.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/mackerelio/mkr/logger"
 )
@@ -25,5 +26,10 @@ type HostFormat struct {
 func PrettyPrintJSON(src interface{}) {
 	data, err := json.MarshalIndent(src, "", "    ")
 	logger.DieIf(err)
-	fmt.Fprintln(os.Stdout, string(data))
+	fmt.Fprintln(os.Stdout, ReplaceAngleBrackets(string(data)))
+}
+
+func ReplaceAngleBrackets(s string) string {
+	s = strings.Replace(s, "\\u003c", "<", -1)
+	return strings.Replace(s, "\\u003e", ">", -1)
 }

--- a/format.go
+++ b/format.go
@@ -24,11 +24,11 @@ type HostFormat struct {
 
 // PrettyPrintJSON output indented json via stdout.
 func PrettyPrintJSON(src interface{}) {
-	fmt.Fprintln(os.Stdout, JSONMarshalIndentWithReplaceAngleBrackets(src, "", "    "))
+	fmt.Fprintln(os.Stdout, JSONMarshalIndent(src, "", "    "))
 }
 
-// JSONMarshalIndentWithReplaceAngleBrackets call json.MarshalIndent and replace encoded angle brackets
-func JSONMarshalIndentWithReplaceAngleBrackets(src interface{}, prefix, indent string) string {
+// JSONMarshalIndent call json.MarshalIndent and replace encoded angle brackets
+func JSONMarshalIndent(src interface{}, prefix, indent string) string {
 	dataRaw, err := json.MarshalIndent(src, prefix, indent)
 	logger.DieIf(err)
 	return replaceAngleBrackets(string(dataRaw))

--- a/format.go
+++ b/format.go
@@ -29,6 +29,7 @@ func PrettyPrintJSON(src interface{}) {
 	fmt.Fprintln(os.Stdout, ReplaceAngleBrackets(string(data)))
 }
 
+// ReplaceAngleBrackets replace encoded angle brackets
 func ReplaceAngleBrackets(s string) string {
 	s = strings.Replace(s, "\\u003c", "<", -1)
 	return strings.Replace(s, "\\u003e", ">", -1)

--- a/format.go
+++ b/format.go
@@ -24,11 +24,11 @@ type HostFormat struct {
 
 // PrettyPrintJSON output indented json via stdout.
 func PrettyPrintJSON(src interface{}) {
-	fmt.Fprintln(os.Stdout, JsonMarshalIndentWithReplaceAngleBrackets(src, "", "    "))
+	fmt.Fprintln(os.Stdout, JSONMarshalIndentWithReplaceAngleBrackets(src, "", "    "))
 }
 
-// PrettyPrintJSON call json.MarshalIndent and replace encoded angle brackets
-func JsonMarshalIndentWithReplaceAngleBrackets(src interface{}, prefix, indent string) string {
+// JSONMarshalIndentWithReplaceAngleBrackets call json.MarshalIndent and replace encoded angle brackets
+func JSONMarshalIndentWithReplaceAngleBrackets(src interface{}, prefix, indent string) string {
 	dataRaw, err := json.MarshalIndent(src, prefix, indent)
 	logger.DieIf(err)
 	return replaceAngleBrackets(string(dataRaw))

--- a/format.go
+++ b/format.go
@@ -24,13 +24,17 @@ type HostFormat struct {
 
 // PrettyPrintJSON output indented json via stdout.
 func PrettyPrintJSON(src interface{}) {
-	data, err := json.MarshalIndent(src, "", "    ")
-	logger.DieIf(err)
-	fmt.Fprintln(os.Stdout, ReplaceAngleBrackets(string(data)))
+	fmt.Fprintln(os.Stdout, JsonMarshalIndentWithReplaceAngleBrackets(src, "", "    "))
 }
 
-// ReplaceAngleBrackets replace encoded angle brackets
-func ReplaceAngleBrackets(s string) string {
+// PrettyPrintJSON call json.MarshalIndent and replace encoded angle brackets
+func JsonMarshalIndentWithReplaceAngleBrackets(src interface{}, prefix, indent string) string {
+	dataRaw, err := json.MarshalIndent(src, prefix, indent)
+	logger.DieIf(err)
+	return replaceAngleBrackets(string(dataRaw))
+}
+
+func replaceAngleBrackets(s string) string {
 	s = strings.Replace(s, "\\u003c", "<", -1)
 	return strings.Replace(s, "\\u003e", ">", -1)
 }

--- a/monitors.go
+++ b/monitors.go
@@ -70,7 +70,7 @@ func monitorSaveRules(rules []*(mkr.Monitor), optFilePath string) error {
 	defer file.Close()
 
 	monitors := map[string]interface{}{"monitors": rules}
-	data := JsonMarshalIndentWithReplaceAngleBrackets(monitors, "", "    ") + "\n"
+	data := JSONMarshalIndentWithReplaceAngleBrackets(monitors, "", "    ") + "\n"
 
 	_, err = file.WriteString(data)
 	if err != nil {
@@ -184,7 +184,7 @@ func appendDiff(src []string, name string, a interface{}, b interface{}) []strin
 }
 
 func stringifyMonitor(a *mkr.Monitor, prefix string) string {
-	data := JsonMarshalIndentWithReplaceAngleBrackets(a, prefix+" ", "  ")
+	data := JSONMarshalIndentWithReplaceAngleBrackets(a, prefix+" ", "  ")
 	return prefix + " " + data + ","
 }
 

--- a/monitors.go
+++ b/monitors.go
@@ -72,7 +72,7 @@ func monitorSaveRules(rules []*(mkr.Monitor), optFilePath string) error {
 	monitors := map[string]interface{}{"monitors": rules}
 	dataRaw, err := json.MarshalIndent(monitors, "", "    ")
 	logger.DieIf(err)
-	data := replaceAngleBrackets(string(dataRaw)) + "\n"
+	data := ReplaceAngleBrackets(string(dataRaw)) + "\n"
 
 	_, err = file.WriteString(data)
 	if err != nil {
@@ -188,13 +188,8 @@ func appendDiff(src []string, name string, a interface{}, b interface{}) []strin
 func stringifyMonitor(a *mkr.Monitor, prefix string) string {
 	dataRaw, err := json.MarshalIndent(a, prefix+" ", "  ")
 	logger.DieIf(err)
-	data := replaceAngleBrackets(string(dataRaw))
+	data := ReplaceAngleBrackets(string(dataRaw))
 	return prefix + " " + data + ","
-}
-
-func replaceAngleBrackets(s string) string {
-	s = strings.Replace(s, "\\u003c", "<", -1)
-	return strings.Replace(s, "\\u003e", ">", -1)
 }
 
 func diffMonitor(a *mkr.Monitor, b *mkr.Monitor) string {

--- a/monitors.go
+++ b/monitors.go
@@ -72,7 +72,6 @@ func monitorSaveRules(rules []*(mkr.Monitor), optFilePath string) error {
 	monitors := map[string]interface{}{"monitors": rules}
 	data := JsonMarshalIndentWithReplaceAngleBrackets(monitors, "", "    ") + "\n"
 
-
 	_, err = file.WriteString(data)
 	if err != nil {
 		return err

--- a/monitors.go
+++ b/monitors.go
@@ -70,7 +70,7 @@ func monitorSaveRules(rules []*(mkr.Monitor), optFilePath string) error {
 	defer file.Close()
 
 	monitors := map[string]interface{}{"monitors": rules}
-	data := JSONMarshalIndentWithReplaceAngleBrackets(monitors, "", "    ") + "\n"
+	data := JSONMarshalIndent(monitors, "", "    ") + "\n"
 
 	_, err = file.WriteString(data)
 	if err != nil {
@@ -184,7 +184,7 @@ func appendDiff(src []string, name string, a interface{}, b interface{}) []strin
 }
 
 func stringifyMonitor(a *mkr.Monitor, prefix string) string {
-	data := JSONMarshalIndentWithReplaceAngleBrackets(a, prefix+" ", "  ")
+	data := JSONMarshalIndent(a, prefix+" ", "  ")
 	return prefix + " " + data + ","
 }
 

--- a/monitors.go
+++ b/monitors.go
@@ -70,9 +70,8 @@ func monitorSaveRules(rules []*(mkr.Monitor), optFilePath string) error {
 	defer file.Close()
 
 	monitors := map[string]interface{}{"monitors": rules}
-	dataRaw, err := json.MarshalIndent(monitors, "", "    ")
-	logger.DieIf(err)
-	data := ReplaceAngleBrackets(string(dataRaw)) + "\n"
+	data := JsonMarshalIndentWithReplaceAngleBrackets(monitors, "", "    ") + "\n"
+
 
 	_, err = file.WriteString(data)
 	if err != nil {
@@ -186,9 +185,7 @@ func appendDiff(src []string, name string, a interface{}, b interface{}) []strin
 }
 
 func stringifyMonitor(a *mkr.Monitor, prefix string) string {
-	dataRaw, err := json.MarshalIndent(a, prefix+" ", "  ")
-	logger.DieIf(err)
-	data := ReplaceAngleBrackets(string(dataRaw))
+	data := JsonMarshalIndentWithReplaceAngleBrackets(a, prefix+" ", "  ")
 	return prefix + " " + data + ","
 }
 


### PR DESCRIPTION
```
$mkr monitors

    {
        "id": "xxxxxxx",
        "name": "expression test 2",
        "type": "expression",
        "operator": "\u003e",
        "warning": 0.02,
        "critical": 0.01
    }
```

`operator` value is encoded on standard out