### PR TITLE
Release version 0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.11.3 (2016-07-14)
+
+* fix `validateRules()`,  when monitor has rule of "expression". #66 (daiksy)
+
+
 ## 0.11.2 (2016-06-23)
 
 * replace angle brackets for json #63 (daiksy)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,10 @@
+mkr (0.11.3-1) stable; urgency=low
+
+  * fix `validateRules()`,  when monitor has rule of "expression". (by daiksy)
+    <https://github.com/mackerelio/mkr/pull/66>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Thu, 14 Jul 2016 05:24:17 +0000
+
 mkr (0.11.2-1) stable; urgency=low
 
   * replace angle brackets for json (by daiksy)

--- a/packaging/rpm/mkr.spec
+++ b/packaging/rpm/mkr.spec
@@ -42,6 +42,9 @@ rm -f %{buildroot}%{_bindir}/${name}
 %{_localbindir}/%{name}
 
 %changelog
+* Thu Jul 14 2016 <mackerel-developers@hatena.ne.jp> - 0.11.3-1
+- fix `validateRules()`,  when monitor has rule of "expression". (by daiksy)
+
 * Thu Jun 23 2016 <mackerel-developers@hatena.ne.jp> - 0.11.2-1
 - replace angle brackets for json (by daiksy)
 


### PR DESCRIPTION
- fix `validateRules()`,  when monitor has rule of "expression". #66