### PR TITLE
Rename a dependent package

### DIFF
--- a/alerts.go
+++ b/alerts.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/urfave/cli.v1"
 	"github.com/fatih/color"
 	mkr "github.com/mackerelio/mackerel-client-go"
 	"github.com/mackerelio/mkr/logger"
+	"gopkg.in/urfave/cli.v1"
 )
 
 var commandAlerts = cli.Command{

--- a/alerts.go
+++ b/alerts.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/codegangsta/cli"
+	"gopkg.in/urfave/cli.v1"
 	"github.com/fatih/color"
 	mkr "github.com/mackerelio/mackerel-client-go"
 	"github.com/mackerelio/mkr/logger"

--- a/commands.go
+++ b/commands.go
@@ -10,9 +10,9 @@ import (
 	"text/template"
 
 	"github.com/Songmu/prompter"
-	"gopkg.in/urfave/cli.v1"
 	mkr "github.com/mackerelio/mackerel-client-go"
 	"github.com/mackerelio/mkr/logger"
+	"gopkg.in/urfave/cli.v1"
 )
 
 // Commands cli.Command object list

--- a/commands.go
+++ b/commands.go
@@ -10,7 +10,7 @@ import (
 	"text/template"
 
 	"github.com/Songmu/prompter"
-	"github.com/codegangsta/cli"
+	"gopkg.in/urfave/cli.v1"
 	mkr "github.com/mackerelio/mackerel-client-go"
 	"github.com/mackerelio/mkr/logger"
 )

--- a/dashboards.go
+++ b/dashboards.go
@@ -7,9 +7,9 @@ import (
 	"strconv"
 	"strings"
 
-	"gopkg.in/urfave/cli.v1"
 	"github.com/mackerelio/mackerel-client-go"
 	"github.com/mackerelio/mkr/logger"
+	"gopkg.in/urfave/cli.v1"
 	"gopkg.in/yaml.v2"
 )
 

--- a/dashboards.go
+++ b/dashboards.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/codegangsta/cli"
+	"gopkg.in/urfave/cli.v1"
 	"github.com/mackerelio/mackerel-client-go"
 	"github.com/mackerelio/mkr/logger"
 	"gopkg.in/yaml.v2"

--- a/mkr.go
+++ b/mkr.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/codegangsta/cli"
+	"gopkg.in/urfave/cli.v1"
 	"github.com/mackerelio/mackerel-agent/config"
 )
 

--- a/mkr.go
+++ b/mkr.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"runtime"
 
-	"gopkg.in/urfave/cli.v1"
 	"github.com/mackerelio/mackerel-agent/config"
+	"gopkg.in/urfave/cli.v1"
 )
 
 func main() {

--- a/monitors.go
+++ b/monitors.go
@@ -10,9 +10,9 @@ import (
 	"sort"
 	"strings"
 
-	"gopkg.in/urfave/cli.v1"
 	mkr "github.com/mackerelio/mackerel-client-go"
 	"github.com/mackerelio/mkr/logger"
+	"gopkg.in/urfave/cli.v1"
 )
 
 var commandMonitors = cli.Command{

--- a/monitors.go
+++ b/monitors.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/codegangsta/cli"
+	"gopkg.in/urfave/cli.v1"
 	mkr "github.com/mackerelio/mackerel-client-go"
 	"github.com/mackerelio/mkr/logger"
 )


### PR DESCRIPTION
github/codegangsta/cli was moved to github.com/urfave/cli.
I use gopkg.in because urfave/cli use version tag.