### PR TITLE
Support `-apibase` option

### DIFF
--- a/alerts.go
+++ b/alerts.go
@@ -182,8 +182,7 @@ func formatJoinedAlert(alertSet *alertSet, colorize bool) string {
 }
 
 func doAlertsRetrieve(c *cli.Context) error {
-	conffile := c.GlobalString("conf")
-	client := newMackerel(conffile)
+	client := newMackerelFromContext(c)
 
 	alerts, err := client.FindAlerts()
 	logger.DieIf(err)
@@ -192,10 +191,9 @@ func doAlertsRetrieve(c *cli.Context) error {
 }
 
 func doAlertsList(c *cli.Context) error {
-	conffile := c.GlobalString("conf")
 	filterServices := c.StringSlice("service")
 	filterStatuses := c.StringSlice("host-status")
-	client := newMackerel(conffile)
+	client := newMackerelFromContext(c)
 
 	alerts, err := client.FindAlerts()
 	logger.DieIf(err)
@@ -234,7 +232,6 @@ func doAlertsList(c *cli.Context) error {
 }
 
 func doAlertsClose(c *cli.Context) error {
-	conffile := c.GlobalString("conf")
 	isVerbose := c.Bool("verbose")
 	argAlertIDs := c.Args()
 	reason := c.String("reason")
@@ -244,7 +241,7 @@ func doAlertsClose(c *cli.Context) error {
 		os.Exit(1)
 	}
 
-	client := newMackerel(conffile)
+	client := newMackerelFromContext(c)
 	for _, alertID := range argAlertIDs {
 		alert, err := client.CloseAlert(alertID, reason)
 		logger.DieIf(err)

--- a/commands.go
+++ b/commands.go
@@ -166,6 +166,7 @@ func assert(err error) {
 
 func newMackerelFromContext(c *cli.Context) *mkr.Client {
 	conffile := c.GlobalString("conf")
+	apiBase := c.GlobalString("apibase")
 	apiKey := LoadApikeyFromEnvOrConfig(conffile)
 	if apiKey == "" {
 		logger.Log("error", `
@@ -174,8 +175,12 @@ func newMackerelFromContext(c *cli.Context) *mkr.Client {
 		os.Exit(1)
 	}
 
+	if apiBase == "" {
+		apiBase = LoadApibaseFromConfig(conffile)
+	}
+
 	if os.Getenv("DEBUG") != "" {
-		mackerel, err := mkr.NewClientWithOptions(apiKey, "https://mackerel.io/api/v0", true)
+		mackerel, err := mkr.NewClientWithOptions(apiKey, apiBase, true)
 		logger.DieIf(err)
 
 		return mackerel

--- a/commands.go
+++ b/commands.go
@@ -164,13 +164,8 @@ func assert(err error) {
 	}
 }
 
-// Utility
 func newMackerelFromContext(c *cli.Context) *mkr.Client {
 	conffile := c.GlobalString("conf")
-	return newMackerel(conffile)
-}
-
-func newMackerel(conffile string) *mkr.Client {
 	apiKey := LoadApikeyFromEnvOrConfig(conffile)
 	if apiKey == "" {
 		logger.Log("error", `

--- a/commands.go
+++ b/commands.go
@@ -179,14 +179,10 @@ func newMackerelFromContext(c *cli.Context) *mkr.Client {
 		apiBase = LoadApibaseFromConfig(conffile)
 	}
 
-	if os.Getenv("DEBUG") != "" {
-		mackerel, err := mkr.NewClientWithOptions(apiKey, apiBase, true)
-		logger.DieIf(err)
+	mackerel, err := mkr.NewClientWithOptions(apiKey, apiBase, os.Getenv("DEBUG") != "")
+	logger.DieIf(err)
 
-		return mackerel
-	}
-
-	return mkr.NewClient(apiKey)
+	return mackerel
 }
 
 type commandDoc struct {

--- a/commands.go
+++ b/commands.go
@@ -164,6 +164,12 @@ func assert(err error) {
 	}
 }
 
+// Utility
+func newMackerelFromContext(c *cli.Context) *mkr.Client {
+	conffile := c.GlobalString("conf")
+	return newMackerel(conffile)
+}
+
 func newMackerel(conffile string) *mkr.Client {
 	apiKey := LoadApikeyFromEnvOrConfig(conffile)
 	if apiKey == "" {
@@ -248,7 +254,7 @@ func doStatus(c *cli.Context) error {
 		}
 	}
 
-	host, err := newMackerel(conffile).FindHost(argHostID)
+	host, err := newMackerelFromContext(c).FindHost(argHostID)
 	logger.DieIf(err)
 
 	if isVerbose {
@@ -271,10 +277,9 @@ func doStatus(c *cli.Context) error {
 }
 
 func doHosts(c *cli.Context) error {
-	conffile := c.GlobalString("conf")
 	isVerbose := c.Bool("verbose")
 
-	hosts, err := newMackerel(conffile).FindHosts(&mkr.FindHostsParam{
+	hosts, err := newMackerelFromContext(c).FindHosts(&mkr.FindHostsParam{
 		Name:     c.String("name"),
 		Service:  c.String("service"),
 		Roles:    c.StringSlice("role"),
@@ -311,7 +316,6 @@ func doHosts(c *cli.Context) error {
 }
 
 func doCreate(c *cli.Context) error {
-	conffile := c.GlobalString("conf")
 	argHostName := c.Args().Get(0)
 	optRoleFullnames := c.StringSlice("roleFullname")
 	optStatus := c.String("status")
@@ -321,7 +325,7 @@ func doCreate(c *cli.Context) error {
 		os.Exit(1)
 	}
 
-	client := newMackerel(conffile)
+	client := newMackerelFromContext(c)
 
 	hostID, err := client.CreateHost(&mkr.CreateHostParam{
 		Name:          argHostName,
@@ -366,7 +370,7 @@ func doUpdate(c *cli.Context) error {
 		os.Exit(1)
 	}
 
-	client := newMackerel(conffile)
+	client := newMackerelFromContext(c)
 
 	for _, hostID := range argHostIDs {
 		if needUpdateHostStatus {
@@ -413,7 +417,6 @@ func doUpdate(c *cli.Context) error {
 }
 
 func doThrow(c *cli.Context) error {
-	conffile := c.GlobalString("conf")
 	optHostID := c.String("host")
 	optService := c.String("service")
 
@@ -450,7 +453,7 @@ func doThrow(c *cli.Context) error {
 	}
 	logger.ErrorIf(scanner.Err())
 
-	client := newMackerel(conffile)
+	client := newMackerelFromContext(c)
 
 	if optHostID != "" {
 		err := client.PostHostMetricValuesByHostID(optHostID, metricValues)
@@ -474,7 +477,6 @@ func doThrow(c *cli.Context) error {
 }
 
 func doFetch(c *cli.Context) error {
-	conffile := c.GlobalString("conf")
 	argHostIDs := c.Args()
 	optMetricNames := c.StringSlice("name")
 
@@ -483,7 +485,7 @@ func doFetch(c *cli.Context) error {
 		os.Exit(1)
 	}
 
-	metricValues, err := newMackerel(conffile).FetchLatestMetricValues(argHostIDs, optMetricNames)
+	metricValues, err := newMackerelFromContext(c).FetchLatestMetricValues(argHostIDs, optMetricNames)
 	logger.DieIf(err)
 
 	PrettyPrintJSON(metricValues)
@@ -508,7 +510,7 @@ func doRetire(c *cli.Context) error {
 		return nil
 	}
 
-	client := newMackerel(conffile)
+	client := newMackerelFromContext(c)
 
 	for _, hostID := range argHostIDs {
 		err := client.RetireHost(hostID)

--- a/config.go
+++ b/config.go
@@ -22,6 +22,15 @@ func loadHostID(root string) (string, error) {
 	return string(content), nil
 }
 
+// LoadApibaseFromConfig gets mackerel api Base URL (usually https://mackerel.io/) from mackerel-agent.conf if it's installed mackerel-agent on localhost
+func LoadApibaseFromConfig(conffile string) string {
+	conf, err := config.LoadConfig(conffile)
+	if err != nil {
+		return ""
+	}
+	return conf.Apibase
+}
+
 // LoadApikeyFromConfig gets mackerel.io apikey from mackerel-agent.conf if it's installed mackerel-agent on localhost
 func LoadApikeyFromConfig(conffile string) string {
 	conf, err := config.LoadConfig(conffile)

--- a/config_test.go
+++ b/config_test.go
@@ -11,8 +11,8 @@ func TestLoadApibaseFromConfig(t *testing.T) {
 
 	apiBase := LoadApibaseFromConfig(conffile)
 
-	if apiBase != "https://OVERRIDE/" {
-		t.Error("should be https://OVERRIDE/")
+	if apiBase != "https://example.com/" {
+		t.Error("should be https://example.com/")
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -6,6 +6,16 @@ import (
 	"testing"
 )
 
+func TestLoadApibaseFromConfig(t *testing.T) {
+	conffile := "test/mackerel-agent.conf"
+
+	apiBase := LoadApibaseFromConfig(conffile)
+
+	if apiBase != "https://OVERRIDE/" {
+		t.Error("should be https://OVERRIDE/")
+	}
+}
+
 func TestLoadApikeyFromConfig(t *testing.T) {
 	conffile := "test/mackerel-agent.conf"
 

--- a/dashboards.go
+++ b/dashboards.go
@@ -347,8 +347,6 @@ func makeImageMarkdown(orgName string, g baseGraph) string {
 }
 
 func doGenerateDashboards(c *cli.Context) error {
-	conffile := c.GlobalString("conf")
-
 	isStdout := c.Bool("print")
 
 	argFilePath := c.Args()
@@ -364,7 +362,7 @@ func doGenerateDashboards(c *cli.Context) error {
 	err = yaml.Unmarshal(buf, &yml)
 	logger.DieIf(err)
 
-	client := newMackerel(conffile)
+	client := newMackerelFromContext(c)
 
 	org, err := client.GetOrg()
 	logger.DieIf(err)

--- a/mkr.go
+++ b/mkr.go
@@ -21,6 +21,11 @@ func main() {
 			Value: config.DefaultConfig.Conffile,
 			Usage: "Config file path",
 		},
+		cli.StringFlag{
+			Name:  "apibase",
+			Value: config.DefaultConfig.Apibase,
+			Usage: "API Base",
+		},
 	}
 
 	cpu := runtime.NumCPU()

--- a/monitors.go
+++ b/monitors.go
@@ -102,9 +102,7 @@ func monitorLoadRules(optFilePath string) ([]*(mkr.Monitor), error) {
 }
 
 func doMonitorsList(c *cli.Context) error {
-	conffile := c.GlobalString("conf")
-
-	monitors, err := newMackerel(conffile).FindMonitors()
+	monitors, err := newMackerelFromContext(c).FindMonitors()
 	logger.DieIf(err)
 
 	PrettyPrintJSON(monitors)
@@ -112,11 +110,10 @@ func doMonitorsList(c *cli.Context) error {
 }
 
 func doMonitorsPull(c *cli.Context) error {
-	conffile := c.GlobalString("conf")
 	isVerbose := c.Bool("verbose")
 	filePath := c.String("file-path")
 
-	monitors, err := newMackerel(conffile).FindMonitors()
+	monitors, err := newMackerelFromContext(c).FindMonitors()
 	logger.DieIf(err)
 
 	monitorSaveRules(monitors, filePath)
@@ -325,12 +322,11 @@ type monitorDiff struct {
 }
 
 func checkMonitorsDiff(c *cli.Context) monitorDiff {
-	conffile := c.GlobalString("conf")
 	filePath := c.String("file-path")
 
 	var monitorDiff monitorDiff
 
-	monitorsRemote, err := newMackerel(conffile).FindMonitors()
+	monitorsRemote, err := newMackerelFromContext(c).FindMonitors()
 	logger.DieIf(err)
 	flagNameUniquenessRemote, err := validateRules(monitorsRemote, "remote rules")
 	logger.DieIf(err)
@@ -402,8 +398,7 @@ func doMonitorsPush(c *cli.Context) error {
 	isDryRun := c.Bool("dry-run")
 	isVerbose := c.Bool("verbose")
 
-	conffile := c.GlobalString("conf")
-	client := newMackerel(conffile)
+	client := newMackerelFromContext(c)
 	if isVerbose {
 		client.Verbose = true
 	}

--- a/test/mackerel-agent.conf
+++ b/test/mackerel-agent.conf
@@ -2,3 +2,4 @@ pidfile = "./pid"
 root = "./test"
 verbose = false
 apikey = "123456ABCD"
+apibase = "https://OVERRIDE/"

--- a/test/mackerel-agent.conf
+++ b/test/mackerel-agent.conf
@@ -2,4 +2,4 @@ pidfile = "./pid"
 root = "./test"
 verbose = false
 apikey = "123456ABCD"
-apibase = "https://OVERRIDE/"
+apibase = "https://example.com/"


### PR DESCRIPTION
Same as mackerel-agent's `-apibase` option.

- if `-apibase` option is supplied, specified value will be used.
- If `-apibase` is not supplied but specified in your mackerel-agent.conf, the value will be used.
  - By this behavior,  default apibase is `https://mackerel.io/`. (Keep current behavior)
