### PR TITLE
[breaking change] Prepend `custom.` prefix to host metric name by default

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -119,6 +119,7 @@ var commandThrow = cli.Command{
 	Flags: []cli.Flag{
 		cli.StringFlag{Name: "host, H", Value: "", Usage: "Post host metric values to <hostID>."},
 		cli.StringFlag{Name: "service, s", Value: "", Usage: "Post service metric values to <service>."},
+		cli.BoolFlag{Name: "keep-metric-name", Usage: "Don't append 'custom.' prefix to host metric name. Ignored on posting service metric values."},
 	},
 }
 
@@ -415,6 +416,7 @@ func doUpdate(c *cli.Context) error {
 func doThrow(c *cli.Context) error {
 	optHostID := c.String("host")
 	optService := c.String("service")
+	optKeepMetricName := c.Bool("keep-metric-name")
 
 	var metricValues []*(mkr.MetricValue)
 
@@ -439,8 +441,13 @@ func doThrow(c *cli.Context) error {
 			continue
 		}
 
+		name := items[0]
+		if optHostID != "" && !optKeepMetricName {
+			name = "custom." + name
+		}
+
 		metricValue := &mkr.MetricValue{
-			Name:  items[0],
+			Name:  name,
 			Value: value,
 			Time:  time,
 		}

--- a/commands.go
+++ b/commands.go
@@ -119,7 +119,6 @@ var commandThrow = cli.Command{
 	Flags: []cli.Flag{
 		cli.StringFlag{Name: "host, H", Value: "", Usage: "Post host metric values to <hostID>."},
 		cli.StringFlag{Name: "service, s", Value: "", Usage: "Post service metric values to <service>."},
-		cli.BoolFlag{Name: "keep-metric-name", Usage: "Don't append 'custom.' prefix to host metric name. Ignored on posting service metric values."},
 	},
 }
 
@@ -416,7 +415,6 @@ func doUpdate(c *cli.Context) error {
 func doThrow(c *cli.Context) error {
 	optHostID := c.String("host")
 	optService := c.String("service")
-	optKeepMetricName := c.Bool("keep-metric-name")
 
 	var metricValues []*(mkr.MetricValue)
 
@@ -442,7 +440,7 @@ func doThrow(c *cli.Context) error {
 		}
 
 		name := items[0]
-		if optHostID != "" && !optKeepMetricName {
+		if optHostID != "" && !strings.HasPrefix(name, "custom.") {
 			name = "custom." + name
 		}
 


### PR DESCRIPTION
We can throw host metrics via `mkr throw -H <hostId>`, and one might combine this feature with mackerel-agent-plugins to post custom host metrics like this:
```
$ mackerel-plugin-mysql --host myrds.com | mkr throw -H <rdsHostId>
```

But, outputs by mackerel-agent-plugin don't have `custom.` prefix in metric name. (Because the prefix is added by mackerel-agent, not by mackerel-agent-plugin).

So I'd like to change `mkr`'s behavior:

## Current behavior
```
$ echo -ne 'some.key' '\t' 12345 '\t' 1476864005 | mkr throw -H <hostId>
```
This command posts following metrics:
```
[{"hostId":"<hostId>","name":"some.key","time":1476864005,"value":12345}]
```

## New behavior

```
$ echo -ne 'some.key' '\t' 12345 '\t' 1476864005 | mkr throw -H <hostId>
```
This command will post following metrics:
```
[{"hostId":"<hostId>","name":"custom.some.key","time":1476864005,"value":12345}]
```

And, if input already has `custom.` prefix, the key will be kept unchanged.

```
$ echo -ne 'custom.some.key' '\t' 12345 '\t' 1476864005 | mkr throw -H <hostId>
```
This will also post:
```
[{"hostId":"<hostId>","name":"custom.some.key","time":1476864005,"value":12345}]
```


<details>
<summary>Outdated</summary>
## New behavior

```
$ echo -ne 'some.key' '\t' 12345 '\t' 1476864005 | mkr throw -H <hostId>
```
This command will post following metrics:
```
[{"hostId":"<hostId>","name":"custom.some.key","time":1476864005,"value":12345}]
```

## `-keep-metric-name` option
Also I implemented `-keep-metric-name` option to `mkr throw`.
With this option, one explicitly specify metric name.

```
$ echo -ne 'custom.some.key' '\t' 12345 '\t' 1476864005 | mkr throw -H <hostId> --keep-metric-name
```
This will post:
```
[{"hostId":"<hostId>","name":"custom.some.key","time":1476864005,"value":12345}]
```

## About service metrics

This change never affects behavior of posting service metrics.  Regardless of `-keep-metric-name` option, original metric names are always kept on posting service metrics.
</details>