### PR TITLE
Release version 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.12.0 (2016-10-27)
+
+* Rename a dependent package #68 (usk81)
+* Support `-apibase` option #69 (astj)
+* [breaking change] Prepend `custom.` prefix to host metric name by default #70 (astj)
+
+
 ## 0.11.3 (2016-07-14)
 
 * fix `validateRules()`,  when monitor has rule of "expression". #66 (daiksy)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,14 @@
+mkr (0.12.0-1) stable; urgency=low
+
+  * Rename a dependent package (by usk81)
+    <https://github.com/mackerelio/mkr/pull/68>
+  * Support `-apibase` option (by astj)
+    <https://github.com/mackerelio/mkr/pull/69>
+  * [breaking change] Prepend `custom.` prefix to host metric name by default (by astj)
+    <https://github.com/mackerelio/mkr/pull/70>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Thu, 27 Oct 2016 02:19:28 +0000
+
 mkr (0.11.3-1) stable; urgency=low
 
   * fix `validateRules()`,  when monitor has rule of "expression". (by daiksy)

--- a/packaging/rpm/mkr.spec
+++ b/packaging/rpm/mkr.spec
@@ -42,6 +42,11 @@ rm -f %{buildroot}%{_bindir}/${name}
 %{_localbindir}/%{name}
 
 %changelog
+* Thu Oct 27 2016 <mackerel-developers@hatena.ne.jp> - 0.12.0-1
+- Rename a dependent package (by usk81)
+- Support `-apibase` option (by astj)
+- [breaking change] Prepend `custom.` prefix to host metric name by default (by astj)
+
 * Thu Jul 14 2016 <mackerel-developers@hatena.ne.jp> - 0.11.3-1
 - fix `validateRules()`,  when monitor has rule of "expression". (by daiksy)
 


### PR DESCRIPTION
- Rename a dependent package #68
- Support `-apibase` option #69
- [breaking change] Prepend `custom.` prefix to host metric name by default #70