### PR TITLE
catch up monitor interface changes of mackerel-client-go

### DIFF
--- a/alerts.go
+++ b/alerts.go
@@ -76,7 +76,7 @@ func joinMonitorsAndHosts(client *mkr.Client, alerts []*mkr.Alert) []*alertSet {
 
 	monitors := map[string]mkr.Monitor{}
 	for _, monitor := range monitorsJSON {
-		monitors[monitorID(monitor)] = monitor
+		monitors[monitor.MonitorID()] = monitor
 	}
 
 	alertSets := []*alertSet{}

--- a/alerts.go
+++ b/alerts.go
@@ -57,7 +57,7 @@ var commandAlerts = cli.Command{
 type alertSet struct {
 	Alert   *mkr.Alert
 	Host    *mkr.Host
-	Monitor *mkr.Monitor
+	Monitor mkr.Monitor
 }
 
 func joinMonitorsAndHosts(client *mkr.Client, alerts []*mkr.Alert) []*alertSet {
@@ -74,9 +74,9 @@ func joinMonitorsAndHosts(client *mkr.Client, alerts []*mkr.Alert) []*alertSet {
 	monitorsJSON, err := client.FindMonitors()
 	logger.DieIf(err)
 
-	monitors := map[string]*mkr.Monitor{}
+	monitors := map[string]mkr.Monitor{}
 	for _, monitor := range monitorsJSON {
-		monitors[monitor.ID] = monitor
+		monitors[monitorID(monitor)] = monitor
 	}
 
 	alertSets := []*alertSet{}
@@ -124,47 +124,47 @@ func formatJoinedAlert(alertSet *alertSet, colorize bool) string {
 
 	monitorMsg := ""
 	if monitor != nil {
-		switch monitor.Type {
-		case "connectivity":
-			monitorMsg = fmt.Sprintf("%s", monitor.Type)
-		case "host":
+		switch m := monitor.(type) {
+		case *mkr.MonitorConnectivity:
+			monitorMsg = fmt.Sprintf("%s", m.Type)
+		case *mkr.MonitorHostMetric:
 			switch alert.Status {
 			case "CRITICAL":
-				monitorMsg = fmt.Sprintf("%s %.2f %s %.2f", monitor.Metric, alert.Value, monitor.Operator, monitor.Critical)
+				monitorMsg = fmt.Sprintf("%s %.2f %s %.2f", m.Metric, alert.Value, m.Operator, m.Critical)
 			case "WARNING":
-				monitorMsg = fmt.Sprintf("%s %.2f %s %.2f", monitor.Metric, alert.Value, monitor.Operator, monitor.Warning)
+				monitorMsg = fmt.Sprintf("%s %.2f %s %.2f", m.Metric, alert.Value, m.Operator, m.Warning)
 			default:
-				monitorMsg = fmt.Sprintf("%s %.2f %s %.2f", monitor.Metric, alert.Value, monitor.Operator, monitor.Critical)
+				monitorMsg = fmt.Sprintf("%s %.2f %s %.2f", m.Metric, alert.Value, m.Operator, m.Critical)
 			}
-		case "service":
+		case *mkr.MonitorServiceMetric:
 			switch alert.Status {
 			case "CRITICAL":
-				monitorMsg = fmt.Sprintf("%s %s %.2f %s %.2f", monitor.Service, monitor.Metric, alert.Value, monitor.Operator, monitor.Critical)
+				monitorMsg = fmt.Sprintf("%s %s %.2f %s %.2f", m.Service, m.Metric, alert.Value, m.Operator, m.Critical)
 			case "WARNING":
-				monitorMsg = fmt.Sprintf("%s %s %.2f %s %.2f", monitor.Service, monitor.Metric, alert.Value, monitor.Operator, monitor.Warning)
+				monitorMsg = fmt.Sprintf("%s %s %.2f %s %.2f", m.Service, m.Metric, alert.Value, m.Operator, m.Warning)
 			default:
-				monitorMsg = fmt.Sprintf("%s %s %.2f %s %.2f", monitor.Service, monitor.Metric, alert.Value, monitor.Operator, monitor.Critical)
+				monitorMsg = fmt.Sprintf("%s %s %.2f %s %.2f", m.Service, m.Metric, alert.Value, m.Operator, m.Critical)
 			}
-		case "external":
+		case *mkr.MonitorExternalHTTP:
 			statusRegexp, _ := regexp.Compile("^[2345][0-9][0-9]$")
 			switch alert.Status {
 			case "CRITICAL":
 				if statusRegexp.MatchString(alert.Message) {
-					monitorMsg = fmt.Sprintf("%s %s %.2f > %.2f msec, status:%s", monitor.Name, monitor.URL, alert.Value, monitor.ResponseTimeCritical, alert.Message)
+					monitorMsg = fmt.Sprintf("%s %s %.2f > %.2f msec, status:%s", m.Name, m.URL, alert.Value, m.ResponseTimeCritical, alert.Message)
 				} else {
-					monitorMsg = fmt.Sprintf("%s %s %.2f msec, %s", monitor.Name, monitor.URL, alert.Value, alert.Message)
+					monitorMsg = fmt.Sprintf("%s %s %.2f msec, %s", m.Name, m.URL, alert.Value, alert.Message)
 				}
 			case "WARNING":
 				if statusRegexp.MatchString(alert.Message) {
-					monitorMsg = fmt.Sprintf("%s %.2f > %.2f msec, status:%s", monitor.Name, alert.Value, monitor.ResponseTimeWarning, alert.Message)
+					monitorMsg = fmt.Sprintf("%s %.2f > %.2f msec, status:%s", m.Name, alert.Value, m.ResponseTimeWarning, alert.Message)
 				} else {
-					monitorMsg = fmt.Sprintf("%s %.2f msec, %s", monitor.Name, alert.Value, alert.Message)
+					monitorMsg = fmt.Sprintf("%s %.2f msec, %s", m.Name, alert.Value, alert.Message)
 				}
 			default:
-				monitorMsg = fmt.Sprintf("%s %.2f > %.2f msec, status:%s", monitor.Name, alert.Value, monitor.ResponseTimeCritical, alert.Message)
+				monitorMsg = fmt.Sprintf("%s %.2f > %.2f msec, status:%s", m.Name, alert.Value, m.ResponseTimeCritical, alert.Message)
 			}
 		default:
-			monitorMsg = fmt.Sprintf("%s", monitor.Type)
+			monitorMsg = fmt.Sprintf("%s", monitor.MonitorType())
 		}
 	}
 	statusMsg := alert.Status
@@ -205,8 +205,14 @@ func doAlertsList(c *cli.Context) error {
 					if _, ok := joinAlert.Host.Roles[filterService]; ok {
 						found = true
 					}
-				} else if joinAlert.Monitor.Service == filterService {
-					found = true
+				} else {
+					var service string
+					if m, ok := joinAlert.Monitor.(*mkr.MonitorServiceMetric); ok {
+						service = m.Service
+					} else if m, ok := joinAlert.Monitor.(*mkr.MonitorExternalHTTP); ok {
+						service = m.Service
+					}
+					found = service == filterService
 				}
 			}
 			if !found {

--- a/alerts_test.go
+++ b/alerts_test.go
@@ -19,7 +19,7 @@ func TestFormatJoinedAlert(t *testing.T) {
 
 	a := &mkr.Alert{ID: "123", Type: "connectivity", Status: "critical", HostID: "1234", MonitorID: "12345", OpenedAt: 100}
 	h := &mkr.Host{ID: "1234", Name: "foo", Roles: mkr.Roles{}, Status: "working"}
-	m := &mkr.Monitor{ID: "12345", Type: "connectivity", URL: "http://example.com", Service: "bar"}
+	m := &mkr.MonitorConnectivity{ID: "12345", Type: "connectivity"}
 	as := alertSet{a, h, m}
 	answer := "123 1970-01-01 00:01:40 critical connectivity foo working []"
 

--- a/monitors.go
+++ b/monitors.go
@@ -289,9 +289,9 @@ func isSameMonitor(a mkr.Monitor, b mkr.Monitor, flagNameUniqueness bool) (strin
 	if reflect.DeepEqual(a, b) {
 		return "", true
 	}
-	aID := monitorID(a)
-	bID := monitorID(b)
-	if aID == bID || (flagNameUniqueness == true && bID == "" && monitorName(a) == monitorName(b)) {
+	aID := a.MonitorID()
+	bID := b.MonitorID()
+	if aID == bID || (flagNameUniqueness == true && bID == "" && a.MonitorName() == b.MonitorName()) {
 		diff := diffMonitor(a, b)
 		if diff != "" {
 			return diff, false
@@ -344,7 +344,7 @@ func validateRules(monitors []mkr.Monitor, label string) (bool, error) {
 	// check name uniqueness
 	names := map[string]bool{}
 	for _, m := range monitors {
-		name := monitorName(m)
+		name := m.MonitorName()
 		if names[name] {
 			logger.Log("Warning: ", fmt.Sprintf("Names of %s are not unique.", label))
 			flagNameUniqueness = false
@@ -459,7 +459,7 @@ func doMonitorsPush(c *cli.Context) error {
 		logger.Log("info", "Delete a rule.")
 		fmt.Println(stringifyMonitor(m, ""))
 		if !isDryRun {
-			_, err := client.DeleteMonitor(monitorID(m))
+			_, err := client.DeleteMonitor(m.MonitorID())
 			logger.DieIf(err)
 		}
 	}
@@ -467,41 +467,9 @@ func doMonitorsPush(c *cli.Context) error {
 		logger.Log("info", "Update a rule.")
 		fmt.Println(stringifyMonitor(d.local, ""))
 		if !isDryRun {
-			_, err := client.UpdateMonitor(monitorID(d.remote), d.local)
+			_, err := client.UpdateMonitor(d.remote.MonitorID(), d.local)
 			logger.DieIf(err)
 		}
 	}
 	return nil
-}
-
-func monitorID(monitor mkr.Monitor) string {
-	switch m := monitor.(type) {
-	case *mkr.MonitorConnectivity:
-		return m.ID
-	case *mkr.MonitorHostMetric:
-		return m.ID
-	case *mkr.MonitorServiceMetric:
-		return m.ID
-	case *mkr.MonitorExternalHTTP:
-		return m.ID
-	case *mkr.MonitorExpression:
-		return m.ID
-	}
-	return ""
-}
-
-func monitorName(monitor mkr.Monitor) string {
-	switch m := monitor.(type) {
-	case *mkr.MonitorConnectivity:
-		return m.Name
-	case *mkr.MonitorHostMetric:
-		return m.Name
-	case *mkr.MonitorServiceMetric:
-		return m.Name
-	case *mkr.MonitorExternalHTTP:
-		return m.Name
-	case *mkr.MonitorExpression:
-		return m.Name
-	}
-	return ""
 }

--- a/monitors.go
+++ b/monitors.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"reflect"
@@ -58,7 +58,7 @@ var commandMonitors = cli.Command{
 	},
 }
 
-func monitorSaveRules(rules []*(mkr.Monitor), optFilePath string) error {
+func monitorSaveRules(rules []mkr.Monitor, optFilePath string) error {
 	filePath := "monitors.json"
 	if optFilePath != "" {
 		filePath = optFilePath
@@ -79,26 +79,67 @@ func monitorSaveRules(rules []*(mkr.Monitor), optFilePath string) error {
 	return nil
 }
 
-func monitorLoadRules(optFilePath string) ([]*(mkr.Monitor), error) {
+func monitorLoadRules(optFilePath string) ([]mkr.Monitor, error) {
 	filePath := "monitors.json"
 	if optFilePath != "" {
 		filePath = optFilePath
 	}
 
-	buff, err := ioutil.ReadFile(filePath)
+	f, err := os.Open(filePath)
 	if err != nil {
 		return nil, err
 	}
+	return decodeMonitors(f)
+}
 
+// decodeMonitors decodes monitors JSON.
+//
+// There are almost same code in mackerel-client-go.
+func decodeMonitors(r io.Reader) ([]mkr.Monitor, error) {
 	var data struct {
-		Monitors []*(mkr.Monitor) `json:"monitors"`
+		Monitors []json.RawMessage `json:"monitors"`
 	}
-
-	err = json.Unmarshal(buff, &data)
-	if err != nil {
+	if err := json.NewDecoder(r).Decode(&data); err != nil {
 		return nil, err
 	}
-	return data.Monitors, nil
+	ms := make([]mkr.Monitor, 0, len(data.Monitors))
+	for _, rawmes := range data.Monitors {
+		m, err := decodeMonitor(rawmes)
+		if err != nil {
+			return nil, err
+		}
+		ms = append(ms, m)
+	}
+	return ms, nil
+}
+
+// decodeMonitor decodes json.RawMessage and returns monitor.
+//
+// There are almost same code in mackerel-client-go.
+func decodeMonitor(mes json.RawMessage) (mkr.Monitor, error) {
+	var typeData struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(mes, &typeData); err != nil {
+		return nil, err
+	}
+	var m mkr.Monitor
+	switch typeData.Type {
+	case "connectivity":
+		m = &mkr.MonitorConnectivity{}
+	case "host":
+		m = &mkr.MonitorHostMetric{}
+	case "service":
+		m = &mkr.MonitorServiceMetric{}
+	case "external":
+		m = &mkr.MonitorExternalHTTP{}
+	case "expression":
+		m = &mkr.MonitorExpression{}
+	}
+	if err := json.Unmarshal(mes, m); err != nil {
+		return nil, err
+	}
+	return m, nil
 }
 
 func doMonitorsList(c *cli.Context) error {
@@ -180,12 +221,12 @@ func appendDiff(src []string, name string, a interface{}, b interface{}) []strin
 	return diff
 }
 
-func stringifyMonitor(a *mkr.Monitor, prefix string) string {
+func stringifyMonitor(a mkr.Monitor, prefix string) string {
 	data := JSONMarshalIndent(a, prefix+" ", "  ")
 	return prefix + " " + data + ","
 }
 
-func diffMonitor(a *mkr.Monitor, b *mkr.Monitor) string {
+func diffMonitor(a mkr.Monitor, b mkr.Monitor) string {
 	diff := []string{"  {"}
 	diffNum := 0
 	sA := reflect.ValueOf(a).Elem()
@@ -241,14 +282,16 @@ func diffMonitor(a *mkr.Monitor, b *mkr.Monitor) string {
 	return ""
 }
 
-func isSameMonitor(a *mkr.Monitor, b *mkr.Monitor, flagNameUniqueness bool) (string, bool) {
+func isSameMonitor(a mkr.Monitor, b mkr.Monitor, flagNameUniqueness bool) (string, bool) {
 	if a == nil || b == nil {
 		return "", false
 	}
-	if reflect.DeepEqual(*a, *b) {
+	if reflect.DeepEqual(a, b) {
 		return "", true
 	}
-	if a.ID == b.ID || (flagNameUniqueness == true && b.ID == "" && a.Name == b.Name) {
+	aID := monitorID(a)
+	bID := monitorID(b)
+	if aID == bID || (flagNameUniqueness == true && bID == "" && monitorName(a) == monitorName(b)) {
 		diff := diffMonitor(a, b)
 		if diff != "" {
 			return diff, false
@@ -258,66 +301,67 @@ func isSameMonitor(a *mkr.Monitor, b *mkr.Monitor, flagNameUniqueness bool) (str
 	return "", false
 }
 
-func validateRules(monitors []*(mkr.Monitor), label string) (bool, error) {
+func validateRules(monitors []mkr.Monitor, label string) (bool, error) {
 
 	flagNameUniqueness := true
 	// check each monitor
-	for _, m := range monitors {
-		v := reflect.ValueOf(m).Elem()
+	for _, monitor := range monitors {
+		v := reflect.ValueOf(monitor).Elem()
 		for _, f := range []string{"Type"} {
 			vf := v.FieldByName(f)
 			if !vf.IsValid() || (vf.Type().String() == "string" && vf.Interface() == "") {
 				return false, fmt.Errorf("Monitor '%s' should have '%s': %s", label, f, v.FieldByName(f).Interface())
 			}
 		}
-		switch m.Type {
-		case "host", "service":
+		switch m := monitor.(type) {
+		case *mkr.MonitorHostMetric, *mkr.MonitorServiceMetric:
 			for _, f := range []string{"Name", "Metric"} {
 				vf := v.FieldByName(f)
 				if !vf.IsValid() || (vf.Type().String() == "string" && vf.Interface() == "") {
 					return false, fmt.Errorf("Monitor '%s' should have '%s': %s", label, f, v.FieldByName(f).Interface())
 				}
 			}
-		case "external":
+		case *mkr.MonitorExternalHTTP:
 			for _, f := range []string{"Name", "URL"} {
 				vf := v.FieldByName(f)
 				if !vf.IsValid() || (vf.Type().String() == "string" && vf.Interface() == "") {
 					return false, fmt.Errorf("Monitor '%s' should have '%s': %s", label, f, v.FieldByName(f).Interface())
 				}
 			}
-		case "expression":
+		case *mkr.MonitorExpression:
 			for _, f := range []string{"Name", "Expression"} {
 				vf := v.FieldByName(f)
 				if !vf.IsValid() || (vf.Type().String() == "string" && vf.Interface() == "") {
 					return false, fmt.Errorf("Monitor '%s' should have '%s': %s", label, f, v.FieldByName(f).Interface())
 				}
 			}
-		case "connectivity":
+		case *mkr.MonitorConnectivity:
 		default:
-			return false, fmt.Errorf("Unknown type is found: %s", m.Type)
+			return false, fmt.Errorf("Unknown type is found: %s", m.MonitorType())
 		}
 	}
 
 	// check name uniqueness
 	names := map[string]bool{}
 	for _, m := range monitors {
-		if names[m.Name] {
+		name := monitorName(m)
+		if names[name] {
 			logger.Log("Warning: ", fmt.Sprintf("Names of %s are not unique.", label))
 			flagNameUniqueness = false
 		}
-		names[m.Name] = true
+		names[name] = true
 	}
 	return flagNameUniqueness, nil
 }
 
 type monitorDiffPair struct {
-	remote *mkr.Monitor
-	local  *mkr.Monitor
+	remote mkr.Monitor
+	local  mkr.Monitor
 }
 
 type monitorDiff struct {
-	onlyRemote []*(mkr.Monitor)
-	onlyLocal  []*(mkr.Monitor)
+	onlyRemote []mkr.Monitor
+	onlyLocal  []mkr.Monitor
 	diff       []*monitorDiffPair
 }
 
@@ -415,7 +459,7 @@ func doMonitorsPush(c *cli.Context) error {
 		logger.Log("info", "Delete a rule.")
 		fmt.Println(stringifyMonitor(m, ""))
 		if !isDryRun {
-			_, err := client.DeleteMonitor(m.ID)
+			_, err := client.DeleteMonitor(monitorID(m))
 			logger.DieIf(err)
 		}
 	}
@@ -423,9 +467,41 @@ func doMonitorsPush(c *cli.Context) error {
 		logger.Log("info", "Update a rule.")
 		fmt.Println(stringifyMonitor(d.local, ""))
 		if !isDryRun {
-			_, err := client.UpdateMonitor(d.remote.ID, d.local)
+			_, err := client.UpdateMonitor(monitorID(d.remote), d.local)
 			logger.DieIf(err)
 		}
 	}
 	return nil
+}
+
+func monitorID(monitor mkr.Monitor) string {
+	switch m := monitor.(type) {
+	case *mkr.MonitorConnectivity:
+		return m.ID
+	case *mkr.MonitorHostMetric:
+		return m.ID
+	case *mkr.MonitorServiceMetric:
+		return m.ID
+	case *mkr.MonitorExternalHTTP:
+		return m.ID
+	case *mkr.MonitorExpression:
+		return m.ID
+	}
+	return ""
+}
+
+func monitorName(monitor mkr.Monitor) string {
+	switch m := monitor.(type) {
+	case *mkr.MonitorConnectivity:
+		return m.Name
+	case *mkr.MonitorHostMetric:
+		return m.Name
+	case *mkr.MonitorServiceMetric:
+		return m.Name
+	case *mkr.MonitorExternalHTTP:
+		return m.Name
+	case *mkr.MonitorExpression:
+		return m.Name
+	}
+	return ""
 }

--- a/monitors_test.go
+++ b/monitors_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func TestIsSameMonitor(t *testing.T) {
-	a := &mkr.Monitor{ID: "12345", Name: "foo", Type: "connectivity"}
-	b := &mkr.Monitor{Name: "foo", Type: "connectivity"}
+	a := &mkr.MonitorConnectivity{ID: "12345", Name: "foo", Type: "connectivity"}
+	b := &mkr.MonitorConnectivity{Name: "foo", Type: "connectivity"}
 
 	_, ret := isSameMonitor(a, b, true)
 	if ret != true {
@@ -24,9 +24,9 @@ func TestIsSameMonitor(t *testing.T) {
 }
 
 func TestValidateRoles(t *testing.T) {
-	a := &mkr.Monitor{ID: "12345", Name: "foo", Type: "connectivity"}
+	a := &mkr.MonitorConnectivity{ID: "12345", Name: "foo", Type: "connectivity"}
 
-	ret, err := validateRules([](*mkr.Monitor){a}, "test monitor")
+	ret, err := validateRules([](mkr.Monitor){a}, "test monitor")
 	if ret != true {
 		t.Errorf("should validate the rule: %s", err.Error())
 	}
@@ -34,8 +34,8 @@ func TestValidateRoles(t *testing.T) {
 }
 
 func TestDiffMonitors(t *testing.T) {
-	a := &mkr.Monitor{ID: "12345", Name: "foo", Type: "external", URL: "http://example.com", Service: "bar", ResponseTimeCritical: 1000}
-	b := &mkr.Monitor{ID: "12345", Name: "foo", Type: "external", URL: "http://example.com", Service: "bar"}
+	a := &mkr.MonitorExternalHTTP{ID: "12345", Name: "foo", Type: "external", URL: "http://example.com", Service: "bar", ResponseTimeCritical: 1000}
+	b := &mkr.MonitorExternalHTTP{ID: "12345", Name: "foo", Type: "external", URL: "http://example.com", Service: "bar"}
 
 	ret := diffMonitor(a, b)
 
@@ -60,7 +60,7 @@ func TestMonitorSaveRules(t *testing.T) {
 	if err != nil {
 		t.Errorf("should not raise error: %v", err)
 	}
-	a := &mkr.Monitor{
+	a := &mkr.MonitorExternalHTTP{
 		ID:                   "12345",
 		Name:                 "foo",
 		Type:                 "external",
@@ -68,7 +68,7 @@ func TestMonitorSaveRules(t *testing.T) {
 		Service:              "bar",
 		ResponseTimeCritical: 1000,
 	}
-	monitorSaveRules([]*mkr.Monitor{a}, tmpFile.Name())
+	monitorSaveRules([]mkr.Monitor{a}, tmpFile.Name())
 
 	byt, _ := ioutil.ReadFile(tmpFile.Name())
 	content := string(byt)
@@ -91,7 +91,7 @@ func TestMonitorSaveRules(t *testing.T) {
 }
 
 func TestStringifyMonitor(t *testing.T) {
-	a := &mkr.Monitor{ID: "12345", Name: "foo", Type: "connectivity"}
+	a := &mkr.MonitorConnectivity{ID: "12345", Name: "foo", Type: "connectivity"}
 	expected := `+ {
 +   "id": "12345",
 +   "name": "foo",
@@ -105,12 +105,12 @@ func TestStringifyMonitor(t *testing.T) {
 }
 
 func TestDiffMonitorsWithScopes(t *testing.T) {
-	a := &mkr.Monitor{
+	a := &mkr.MonitorConnectivity{
 		ID:   "12345",
 		Name: "foo",
 		Type: "connectivity",
 	}
-	b := &mkr.Monitor{
+	b := &mkr.MonitorConnectivity{
 		ID:     "12345",
 		Name:   "foo",
 		Type:   "connectivity",
@@ -140,7 +140,7 @@ func TestDiffMonitorsWithScopes(t *testing.T) {
 		t.Errorf("expected:\n%s\n, output:\n%s\n", expected, diff)
 	}
 
-	c := &mkr.Monitor{
+	c := &mkr.MonitorConnectivity{
 		ID:     "12345",
 		Name:   "foo",
 		Type:   "connectivity",
@@ -160,7 +160,7 @@ func TestDiffMonitorsWithScopes(t *testing.T) {
 		t.Errorf("expected:\n%s\n, output:\n%s\n", expected, diff)
 	}
 
-	d := &mkr.Monitor{
+	d := &mkr.MonitorConnectivity{
 		ID:     "12345",
 		Name:   "foo",
 		Type:   "connectivity",


### PR DESCRIPTION
This p-r catches up the change of monitor interface of mackerel-client.go https://github.com/mackerelio/mackerel-client-go/issues/30

https://github.com/mackerelio/mackerel-client-go/issues/31 and https://github.com/mackerelio/mackerel-client-go/issues/32 must be merged before merging this p-r.