### PR TITLE
Introduce yudai/gojsondiff for `mkr monitors diff`

### DIFF
--- a/monitors.go
+++ b/monitors.go
@@ -182,8 +182,7 @@ func appendDiff(src []string, name string, a interface{}, b interface{}) []strin
 }
 
 func stringifyMonitor(a *mkr.Monitor, prefix string) string {
-	data := JSONMarshalIndent(a, prefix+" ", "  ")
-	return prefix + " " + data + ","
+	return prefix + JSONMarshalIndent(a, prefix, "  ") + ","
 }
 
 // diffMonitor returns JSON diff between monitors.
@@ -202,7 +201,7 @@ func diffMonitor(a *mkr.Monitor, b *mkr.Monitor) string {
 	if err != nil {
 		return ""
 	}
-	return strings.TrimRight(result, "\n")
+	return strings.TrimRight(result, "\n") + ","
 }
 
 func filterIDLine(s string) string {

--- a/monitors.go
+++ b/monitors.go
@@ -7,11 +7,12 @@ import (
 	"log"
 	"os"
 	"reflect"
-	"sort"
 	"strings"
 
 	mkr "github.com/mackerelio/mackerel-client-go"
 	"github.com/mackerelio/mkr/logger"
+	"github.com/yudai/gojsondiff"
+	"github.com/yudai/gojsondiff/formatter"
 	"gopkg.in/urfave/cli.v1"
 )
 
@@ -185,60 +186,35 @@ func stringifyMonitor(a *mkr.Monitor, prefix string) string {
 	return prefix + " " + data + ","
 }
 
+// diffMonitor returns JSON diff between monitors.
+// In order to use `mkr monitors` without pull and to manage monitors by name
+// only, it skips top level "id" field
 func diffMonitor(a *mkr.Monitor, b *mkr.Monitor) string {
-	diff := []string{"  {"}
-	diffNum := 0
-	sA := reflect.ValueOf(a).Elem()
-	sB := reflect.ValueOf(b).Elem()
-	for i := 0; i < sA.NumField(); i++ {
-		fA := sA.Field(i)
-		fB := sB.Field(i)
-		sAType := sA.Type()
-		if sAType.Field(i).Type.String() != "[]string" {
-			name := strings.Replace(sAType.Field(i).Tag.Get("json"), ",omitempty", "", 1)
-			if name == "id" {
-				continue
-			}
-			diff = appendDiff(diff, name, fA.Interface(), fB.Interface())
-			if fA.Interface() != fB.Interface() {
-				diffNum++
-			}
-		} else {
-			if len(fA.Interface().([]string)) == 0 && len(fB.Interface().([]string)) == 0 {
-				continue
-			}
-			name := strings.Replace(sAType.Field(i).Tag.Get("json"), ",omitempty", "", 1)
-			diff = append(diff, fmt.Sprintf("    \"%s\": [", name))
-			sortA := fA.Interface().([]string)
-			sortB := fB.Interface().([]string)
-			sort.Strings(sortA)
-			sort.Strings(sortB)
-			i := 0
-			j := 0
-			for i < len(sortA) || j < len(sortB) {
-				if j >= len(sortB) || (i < len(sortA) && sortA[i] < sortB[j]) {
-					diff = append(diff, fmt.Sprintf("-     \"%s\",", sortA[i]))
-					i++
-					diffNum++
-				} else if i >= len(sortA) || sortB[j] < sortA[i] {
-					diff = append(diff, fmt.Sprintf("+     \"%s\",", sortB[j]))
-					j++
-					diffNum++
-				} else {
-					diff = append(diff, fmt.Sprintf("      \"%s\",", sortA[i]))
-					i++
-					j++
-				}
-			}
-			diff = append(diff, "    ],")
-		}
+	as := filterIDLine(JSONMarshalIndent(a, " ", "  "))
+	bs := filterIDLine(JSONMarshalIndent(b, " ", "  "))
+	diff, err := gojsondiff.New().Compare([]byte(as), []byte(bs))
+	if err != nil || !diff.Modified() {
+		return ""
 	}
+	var left map[string]interface{}
+	json.Unmarshal([]byte(as), &left)
+	result, err := formatter.NewAsciiFormatter(left).Format(diff)
+	if err != nil {
+		return ""
+	}
+	return result
+}
 
-	if diffNum > 0 {
-		diff = append(diff, "  },")
-		return strings.Join(diff, "\n")
+func filterIDLine(s string) string {
+	lines := strings.Split(s, "\n")
+	filtered := make([]string, 0, len(lines))
+	for _, l := range lines {
+		if strings.HasPrefix(l, `   "id":`) {
+			continue
+		}
+		filtered = append(filtered, l)
 	}
-	return ""
+	return strings.Join(filtered, "\n")
 }
 
 func isSameMonitor(a *mkr.Monitor, b *mkr.Monitor, flagNameUniqueness bool) (string, bool) {

--- a/monitors.go
+++ b/monitors.go
@@ -202,7 +202,7 @@ func diffMonitor(a *mkr.Monitor, b *mkr.Monitor) string {
 	if err != nil {
 		return ""
 	}
-	return result
+	return strings.TrimRight(result, "\n")
 }
 
 func filterIDLine(s string) string {

--- a/monitors_test.go
+++ b/monitors_test.go
@@ -39,7 +39,7 @@ func TestDiffMonitors(t *testing.T) {
    "service": "bar",
    "type": "external",
    "url": "http://example.com"
- }`
+ },`
 	a := &mkr.Monitor{ID: "12345", Name: "foo", Type: "external", URL: "http://example.com", Service: "bar", ResponseTimeCritical: 1000}
 	b := &mkr.Monitor{ID: "12345", Name: "foo", Type: "external", URL: "http://example.com", Service: "bar"}
 	if got := diffMonitor(a, b); got != want {
@@ -84,11 +84,11 @@ func TestMonitorSaveRules(t *testing.T) {
 
 func TestStringifyMonitor(t *testing.T) {
 	a := &mkr.Monitor{ID: "12345", Name: "foo", Type: "connectivity"}
-	expected := `+ {
-+   "id": "12345",
-+   "name": "foo",
-+   "type": "connectivity"
-+ },`
+	expected := `+{
++  "id": "12345",
++  "name": "foo",
++  "type": "connectivity"
++},`
 
 	r := stringifyMonitor(a, "+")
 	if r != expected {
@@ -115,7 +115,7 @@ func TestDiffMonitorsWithScopes(t *testing.T) {
 +  "scopes": [
 +    "sss: notebook"
 +  ]
- }`
+ },`
 	if diff != expected {
 		// t.Error(debugdiff.Diff(expected, diff))
 		t.Errorf("expected:\n%s\n, output:\n%s\n", expected, diff)
@@ -128,7 +128,7 @@ func TestDiffMonitorsWithScopes(t *testing.T) {
 -    "sss: notebook"
 -  ],
    "type": "connectivity"
- }`
+ },`
 	if diff != expected {
 		t.Errorf("expected:\n%s\n, output:\n%s\n", expected, diff)
 	}
@@ -148,7 +148,7 @@ func TestDiffMonitorsWithScopes(t *testing.T) {
 +    "ttt: notebook"
    ],
    "type": "connectivity"
- }`
+ },`
 	if diff != expected {
 		t.Errorf("expected:\n%s\n, output:\n%s\n", expected, diff)
 	}
@@ -167,7 +167,7 @@ func TestDiffMonitorsWithScopes(t *testing.T) {
 +    "ttt: notebook"
    ],
    "type": "connectivity"
- }`
+ },`
 	if diff != expected {
 		t.Errorf("expected:\n%s\n, output:\n%s\n", expected, diff)
 	}

--- a/monitors_test.go
+++ b/monitors_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"io/ioutil"
-	"strings"
 	"testing"
 
 	mkr "github.com/mackerelio/mackerel-client-go"
@@ -34,24 +33,18 @@ func TestValidateRoles(t *testing.T) {
 }
 
 func TestDiffMonitors(t *testing.T) {
+	const want = ` {
+   "name": "foo",
+-  "responseTimeCritical": 1000,
+   "service": "bar",
+   "type": "external",
+   "url": "http://example.com"
+ }
+`
 	a := &mkr.Monitor{ID: "12345", Name: "foo", Type: "external", URL: "http://example.com", Service: "bar", ResponseTimeCritical: 1000}
 	b := &mkr.Monitor{ID: "12345", Name: "foo", Type: "external", URL: "http://example.com", Service: "bar"}
-
-	ret := diffMonitor(a, b)
-
-	correct := strings.Join([]string{
-		"  {",
-		"    \"name\": \"foo\",",
-		"    \"type\": \"external\",",
-		"    \"url\": \"http://example.com\",",
-		"    \"service\": \"bar\",",
-		"-   \"responseTimeCritical\": 1000.000000,",
-		"+   \"responseTimeCritical\": 0.000000,",
-		"  },",
-	}, "\n")
-
-	if ret != correct {
-		t.Errorf("should validate the rule: %s\nbut result: %s", correct, ret)
+	if got := diffMonitor(a, b); got != want {
+		t.Errorf("diffMonitor: got\n%s\nwant \n%s", got, want)
 	}
 }
 
@@ -117,25 +110,28 @@ func TestDiffMonitorsWithScopes(t *testing.T) {
 		Scopes: []string{"sss: notebook"},
 	}
 	diff := diffMonitor(a, b)
-	expected := `  {
-    "name": "foo",
-    "type": "connectivity",
-    "scopes": [
-+     "sss: notebook",
-    ],
-  },`
+	expected := ` {
+   "name": "foo",
+   "type": "connectivity"
++  "scopes": [
++    "sss: notebook"
++  ]
+ }
+`
 	if diff != expected {
+		// t.Error(debugdiff.Diff(expected, diff))
 		t.Errorf("expected:\n%s\n, output:\n%s\n", expected, diff)
 	}
 
 	diff = diffMonitor(b, a)
-	expected = `  {
-    "name": "foo",
-    "type": "connectivity",
-    "scopes": [
--     "sss: notebook",
-    ],
-  },`
+	expected = ` {
+   "name": "foo",
+-  "scopes": [
+-    "sss: notebook"
+-  ],
+   "type": "connectivity"
+ }
+`
 	if diff != expected {
 		t.Errorf("expected:\n%s\n, output:\n%s\n", expected, diff)
 	}
@@ -148,14 +144,15 @@ func TestDiffMonitorsWithScopes(t *testing.T) {
 	}
 
 	diff = diffMonitor(b, c)
-	expected = `  {
-    "name": "foo",
-    "type": "connectivity",
-    "scopes": [
-      "sss: notebook",
-+     "ttt: notebook",
-    ],
-  },`
+	expected = ` {
+   "name": "foo",
+   "scopes": [
+     "sss: notebook"
++    "ttt: notebook"
+   ],
+   "type": "connectivity"
+ }
+`
 	if diff != expected {
 		t.Errorf("expected:\n%s\n, output:\n%s\n", expected, diff)
 	}
@@ -167,14 +164,15 @@ func TestDiffMonitorsWithScopes(t *testing.T) {
 		Scopes: []string{"ttt: notebook"},
 	}
 	diff = diffMonitor(b, d)
-	expected = `  {
-    "name": "foo",
-    "type": "connectivity",
-    "scopes": [
--     "sss: notebook",
-+     "ttt: notebook",
-    ],
-  },`
+	expected = ` {
+   "name": "foo",
+   "scopes": [
+-    "sss: notebook"
++    "ttt: notebook"
+   ],
+   "type": "connectivity"
+ }
+`
 	if diff != expected {
 		t.Errorf("expected:\n%s\n, output:\n%s\n", expected, diff)
 	}

--- a/monitors_test.go
+++ b/monitors_test.go
@@ -117,7 +117,6 @@ func TestDiffMonitorsWithScopes(t *testing.T) {
 +  ]
  },`
 	if diff != expected {
-		// t.Error(debugdiff.Diff(expected, diff))
 		t.Errorf("expected:\n%s\n, output:\n%s\n", expected, diff)
 	}
 

--- a/monitors_test.go
+++ b/monitors_test.go
@@ -39,8 +39,7 @@ func TestDiffMonitors(t *testing.T) {
    "service": "bar",
    "type": "external",
    "url": "http://example.com"
- }
-`
+ }`
 	a := &mkr.Monitor{ID: "12345", Name: "foo", Type: "external", URL: "http://example.com", Service: "bar", ResponseTimeCritical: 1000}
 	b := &mkr.Monitor{ID: "12345", Name: "foo", Type: "external", URL: "http://example.com", Service: "bar"}
 	if got := diffMonitor(a, b); got != want {
@@ -116,8 +115,7 @@ func TestDiffMonitorsWithScopes(t *testing.T) {
 +  "scopes": [
 +    "sss: notebook"
 +  ]
- }
-`
+ }`
 	if diff != expected {
 		// t.Error(debugdiff.Diff(expected, diff))
 		t.Errorf("expected:\n%s\n, output:\n%s\n", expected, diff)
@@ -130,8 +128,7 @@ func TestDiffMonitorsWithScopes(t *testing.T) {
 -    "sss: notebook"
 -  ],
    "type": "connectivity"
- }
-`
+ }`
 	if diff != expected {
 		t.Errorf("expected:\n%s\n, output:\n%s\n", expected, diff)
 	}
@@ -151,8 +148,7 @@ func TestDiffMonitorsWithScopes(t *testing.T) {
 +    "ttt: notebook"
    ],
    "type": "connectivity"
- }
-`
+ }`
 	if diff != expected {
 		t.Errorf("expected:\n%s\n, output:\n%s\n", expected, diff)
 	}
@@ -171,8 +167,7 @@ func TestDiffMonitorsWithScopes(t *testing.T) {
 +    "ttt: notebook"
    ],
    "type": "connectivity"
- }
-`
+ }`
 	if diff != expected {
 		t.Errorf("expected:\n%s\n, output:\n%s\n", expected, diff)
 	}


### PR DESCRIPTION
This p-r introduces https://github.com/yudai/gojsondiff for `mkr monitors diff` and removes the existed ad-hoc monitor diff implementation.

The ad-hoc implementation only supported flat JSON field and array of string, but we'll need to support more complex field like `headers` field for external monitoring. https://mackerel.io/api-docs/entry/monitors#create. We don't want to maintain ad-hoc monitor diff implementation anymore.

The format of output JSON diff is slightly different from old one, but I think the difference is acceptable.
