### PR TITLE
Release version 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.13.0 (2016-11-29)
+
+* remove unreachable code: monitor type cannot be "check" #72 (haya14busa)
+* Fix the links to the api documents #73 (itchyny)
+* catch up monitor interface changes of mackerel-client-go #74 (haya14busa)
+* Introduce yudai/gojsondiff for `mkr monitors diff` #75 (haya14busa)
+* fix test according to mackerel-client-go changes #76 (haya14busa)
+
+
 ## 0.12.0 (2016-10-27)
 
 * Rename a dependent package #68 (usk81)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,18 @@
+mkr (0.13.0-1) stable; urgency=low
+
+  * remove unreachable code: monitor type cannot be "check" (by haya14busa)
+    <https://github.com/mackerelio/mkr/pull/72>
+  * Fix the links to the api documents (by itchyny)
+    <https://github.com/mackerelio/mkr/pull/73>
+  * catch up monitor interface changes of mackerel-client-go (by haya14busa)
+    <https://github.com/mackerelio/mkr/pull/74>
+  * Introduce yudai/gojsondiff for `mkr monitors diff` (by haya14busa)
+    <https://github.com/mackerelio/mkr/pull/75>
+  * fix test according to mackerel-client-go changes (by haya14busa)
+    <https://github.com/mackerelio/mkr/pull/76>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Tue, 29 Nov 2016 06:01:34 +0000
+
 mkr (0.12.0-1) stable; urgency=low
 
   * Rename a dependent package (by usk81)

--- a/packaging/rpm/mkr.spec
+++ b/packaging/rpm/mkr.spec
@@ -42,6 +42,13 @@ rm -f %{buildroot}%{_bindir}/${name}
 %{_localbindir}/%{name}
 
 %changelog
+* Tue Nov 29 2016 <mackerel-developers@hatena.ne.jp> - 0.13.0-1
+- remove unreachable code: monitor type cannot be "check" (by haya14busa)
+- Fix the links to the api documents (by itchyny)
+- catch up monitor interface changes of mackerel-client-go (by haya14busa)
+- Introduce yudai/gojsondiff for `mkr monitors diff` (by haya14busa)
+- fix test according to mackerel-client-go changes (by haya14busa)
+
 * Thu Oct 27 2016 <mackerel-developers@hatena.ne.jp> - 0.12.0-1
 - Rename a dependent package (by usk81)
 - Support `-apibase` option (by astj)


### PR DESCRIPTION
- remove unreachable code: monitor type cannot be "check" #72
- Fix the links to the api documents #73
- catch up monitor interface changes of mackerel-client-go #74
- Introduce yudai/gojsondiff for `mkr monitors diff` #75
- fix test according to mackerel-client-go changes #76