### PR TITLE
Support expression monitor alerts in mkr alerts list

### DIFF
--- a/alerts.go
+++ b/alerts.go
@@ -164,7 +164,7 @@ func formatJoinedAlert(alertSet *alertSet, colorize bool) string {
 				monitorMsg = fmt.Sprintf("%.2f > %.2f msec, status:%s", alert.Value, m.ResponseTimeCritical, alert.Message)
 			}
 		case *mkr.MonitorExpression:
-			expression := trimExpression(m.Expression)
+			expression := formatExpressionOneline(m.Expression)
 			switch alert.Status {
 			case "CRITICAL":
 				monitorMsg = fmt.Sprintf("%s %.2f %s %.2f", expression, alert.Value, m.Operator, m.Critical)
@@ -200,8 +200,8 @@ func formatJoinedAlert(alertSet *alertSet, colorize bool) string {
 
 var expressionTrimmer = regexp.MustCompile(`[\r\n]+\s*`)
 
-func trimExpression(expr string) string {
-	return expressionTrimmer.ReplaceAllString(expr, " ")
+func formatExpressionOneline(expr string) string {
+	return strings.Trim(expressionTrimmer.ReplaceAllString(expr, " "), " ")
 }
 
 func doAlertsRetrieve(c *cli.Context) error {

--- a/alerts.go
+++ b/alerts.go
@@ -163,6 +163,18 @@ func formatJoinedAlert(alertSet *alertSet, colorize bool) string {
 			default:
 				monitorMsg = fmt.Sprintf("%s %.2f > %.2f msec, status:%s", m.Name, alert.Value, m.ResponseTimeCritical, alert.Message)
 			}
+		case *mkr.MonitorExpression:
+			expression := trimExpression(m.Expression)
+			switch alert.Status {
+			case "CRITICAL":
+				monitorMsg = fmt.Sprintf("%s %.2f %s %.2f", expression, alert.Value, m.Operator, m.Critical)
+			case "WARNING":
+				monitorMsg = fmt.Sprintf("%s %.2f %s %.2f", expression, alert.Value, m.Operator, m.Warning)
+			case "UNKNOWN":
+				monitorMsg = fmt.Sprintf("%s", expression)
+			default:
+				monitorMsg = fmt.Sprintf("%s %.2f", expression, alert.Value)
+			}
 		default:
 			monitorMsg = fmt.Sprintf("%s", monitor.MonitorType())
 		}
@@ -174,9 +186,17 @@ func formatJoinedAlert(alertSet *alertSet, colorize bool) string {
 			statusMsg = color.RedString("CRITICAL")
 		case "WARNING":
 			statusMsg = color.YellowString("WARNING ")
+		case "UNKNOWN":
+			statusMsg = "UNKNOWN "
 		}
 	}
 	return fmt.Sprintf("%s %s %s %s%s", alert.ID, time.Unix(alert.OpenedAt, 0).Format(layout), statusMsg, monitorMsg, hostMsg)
+}
+
+var expressionTrimmer = regexp.MustCompile(`[\r\n]+\s*`)
+
+func trimExpression(expr string) string {
+	return expressionTrimmer.ReplaceAllString(expr, " ")
 }
 
 func doAlertsRetrieve(c *cli.Context) error {

--- a/alerts.go
+++ b/alerts.go
@@ -201,7 +201,8 @@ func formatJoinedAlert(alertSet *alertSet, colorize bool) string {
 var expressionTrimmer = regexp.MustCompile(`[\r\n]+\s*`)
 
 func formatExpressionOneline(expr string) string {
-	return strings.Trim(expressionTrimmer.ReplaceAllString(expr, " "), " ")
+	expr = strings.Trim(expressionTrimmer.ReplaceAllString(expr, " "), " ")
+	return strings.Replace(strings.Replace(expr, "( ", "(", -1), " )", ")", -1)
 }
 
 func doAlertsRetrieve(c *cli.Context) error {

--- a/alerts.go
+++ b/alerts.go
@@ -126,7 +126,7 @@ func formatJoinedAlert(alertSet *alertSet, colorize bool) string {
 	if monitor != nil {
 		switch m := monitor.(type) {
 		case *mkr.MonitorConnectivity:
-			monitorMsg = fmt.Sprintf("%s", m.Type)
+			monitorMsg = ""
 		case *mkr.MonitorHostMetric:
 			switch alert.Status {
 			case "CRITICAL":
@@ -150,18 +150,18 @@ func formatJoinedAlert(alertSet *alertSet, colorize bool) string {
 			switch alert.Status {
 			case "CRITICAL":
 				if statusRegexp.MatchString(alert.Message) {
-					monitorMsg = fmt.Sprintf("%s %s %.2f > %.2f msec, status:%s", m.Name, m.URL, alert.Value, m.ResponseTimeCritical, alert.Message)
+					monitorMsg = fmt.Sprintf("%s %.2f > %.2f msec, status:%s", m.URL, alert.Value, m.ResponseTimeCritical, alert.Message)
 				} else {
-					monitorMsg = fmt.Sprintf("%s %s %.2f msec, %s", m.Name, m.URL, alert.Value, alert.Message)
+					monitorMsg = fmt.Sprintf("%s %.2f msec, %s", m.URL, alert.Value, alert.Message)
 				}
 			case "WARNING":
 				if statusRegexp.MatchString(alert.Message) {
-					monitorMsg = fmt.Sprintf("%s %.2f > %.2f msec, status:%s", m.Name, alert.Value, m.ResponseTimeWarning, alert.Message)
+					monitorMsg = fmt.Sprintf("%.2f > %.2f msec, status:%s", alert.Value, m.ResponseTimeWarning, alert.Message)
 				} else {
-					monitorMsg = fmt.Sprintf("%s %.2f msec, %s", m.Name, alert.Value, alert.Message)
+					monitorMsg = fmt.Sprintf("%.2f msec, %s", alert.Value, alert.Message)
 				}
 			default:
-				monitorMsg = fmt.Sprintf("%s %.2f > %.2f msec, status:%s", m.Name, alert.Value, m.ResponseTimeCritical, alert.Message)
+				monitorMsg = fmt.Sprintf("%.2f > %.2f msec, status:%s", alert.Value, m.ResponseTimeCritical, alert.Message)
 			}
 		case *mkr.MonitorExpression:
 			expression := trimExpression(m.Expression)
@@ -177,6 +177,11 @@ func formatJoinedAlert(alertSet *alertSet, colorize bool) string {
 			}
 		default:
 			monitorMsg = fmt.Sprintf("%s", monitor.MonitorType())
+		}
+		if monitorMsg == "" {
+			monitorMsg = monitor.MonitorName()
+		} else {
+			monitorMsg = monitor.MonitorName() + " " + monitorMsg
 		}
 	}
 	statusMsg := alert.Status

--- a/alerts.go
+++ b/alerts.go
@@ -198,10 +198,10 @@ func formatJoinedAlert(alertSet *alertSet, colorize bool) string {
 	return fmt.Sprintf("%s %s %s %s%s", alert.ID, time.Unix(alert.OpenedAt, 0).Format(layout), statusMsg, monitorMsg, hostMsg)
 }
 
-var expressionTrimmer = regexp.MustCompile(`[\r\n]+\s*`)
+var expressionNewlinePattern = regexp.MustCompile(`\s*[\r\n]+\s*`)
 
 func formatExpressionOneline(expr string) string {
-	expr = strings.Trim(expressionTrimmer.ReplaceAllString(expr, " "), " ")
+	expr = strings.Trim(expressionNewlinePattern.ReplaceAllString(expr, " "), " ")
 	return strings.Replace(strings.Replace(expr, "( ", "(", -1), " )", ")", -1)
 }
 

--- a/alerts_test.go
+++ b/alerts_test.go
@@ -59,7 +59,7 @@ func TestFormatJoinedAlert(t *testing.T) {
 				nil,
 				&mkr.MonitorExpression{ID: "5rXR3", Type: "expression", Name: "Max loadavg5 monitor", Expression: "max(\n  roleSlots(\n    'service:role',\n    'loadavg5'\n  )\n)\n", Warning: 10.0, Critical: 20.0, Operator: ">"},
 			},
-			"2tZhm 1970-01-01 00:08:20 WARNING Max loadavg5 monitor max( roleSlots( 'service:role', 'loadavg5' ) ) 15.70 > 10.00",
+			"2tZhm 1970-01-01 00:08:20 WARNING Max loadavg5 monitor max(roleSlots('service:role', 'loadavg5')) 15.70 > 10.00",
 		},
 	}
 

--- a/alerts_test.go
+++ b/alerts_test.go
@@ -57,7 +57,7 @@ func TestFormatJoinedAlert(t *testing.T) {
 			&alertSet{
 				&mkr.Alert{ID: "2tZhm", Type: "expression", Status: "WARNING", MonitorID: "5rXR3", Value: 15.7, OpenedAt: 500},
 				nil,
-				&mkr.MonitorExpression{ID: "5rXR3", Type: "expression", Name: "Max loadavg5 monitor", Expression: "max(\n  roleSlots(\n    'service:role',\n    'loadavg5'\n  )\n)\n", Warning: 10.0, Critical: 20.0, Operator: ">"},
+				&mkr.MonitorExpression{ID: "5rXR3", Type: "expression", Name: "Max loadavg5 monitor", Expression: "max(  \n  roleSlots(  \n    'service:role',\n    'loadavg5'\n  )\n)\n", Warning: 10.0, Critical: 20.0, Operator: ">"},
 			},
 			"2tZhm 1970-01-01 00:08:20 WARNING Max loadavg5 monitor max(roleSlots('service:role', 'loadavg5')) 15.70 > 10.00",
 		},

--- a/alerts_test.go
+++ b/alerts_test.go
@@ -17,14 +17,24 @@ func TestFormatJoinedAlert(t *testing.T) {
 	}
 	time.Local = loc
 
-	a := &mkr.Alert{ID: "123", Type: "connectivity", Status: "critical", HostID: "1234", MonitorID: "12345", OpenedAt: 100}
-	h := &mkr.Host{ID: "1234", Name: "foo", Roles: mkr.Roles{}, Status: "working"}
-	m := &mkr.MonitorConnectivity{ID: "12345", Type: "connectivity"}
-	as := alertSet{a, h, m}
-	answer := "123 1970-01-01 00:01:40 critical connectivity foo working []"
+	testCases := []struct {
+		alertSet *alertSet
+		want     string
+	}{
+		{
+			&alertSet{
+				&mkr.Alert{ID: "2tZhm", Type: "connectivity", Status: "critical", HostID: "3XYyG", MonitorID: "5rXR3", OpenedAt: 100},
+				&mkr.Host{ID: "3XYyG", Name: "foo", Roles: mkr.Roles{}, Status: "working"},
+				&mkr.MonitorConnectivity{ID: "5rXR3", Type: "connectivity"},
+			},
+			"2tZhm 1970-01-01 00:01:40 critical connectivity foo working []",
+		},
+	}
 
-	str := formatJoinedAlert(&as, false)
-	if str != answer {
-		t.Errorf("should be '%s' but '%s'", answer, str)
+	for _, testCase := range testCases {
+		str := formatJoinedAlert(testCase.alertSet, false)
+		if str != testCase.want {
+			t.Errorf("should be '%s' but '%s'", testCase.want, str)
+		}
 	}
 }

--- a/alerts_test.go
+++ b/alerts_test.go
@@ -53,6 +53,14 @@ func TestFormatJoinedAlert(t *testing.T) {
 			},
 			"2tZhm 1970-01-01 00:06:40 CRITICAL Example Domain https://example.com 2500.00 > 1000.00 msec, status:200",
 		},
+		{
+			&alertSet{
+				&mkr.Alert{ID: "2tZhm", Type: "expression", Status: "WARNING", MonitorID: "5rXR3", Value: 15.7, OpenedAt: 500},
+				nil,
+				&mkr.MonitorExpression{ID: "5rXR3", Type: "expression", Name: "Max loadavg5 monitor", Expression: "max(\n  roleSlots(\n    'service:role',\n    'loadavg5'\n  )\n)\n", Warning: 10.0, Critical: 20.0, Operator: ">"},
+			},
+			"2tZhm 1970-01-01 00:08:20 WARNING Max loadavg5 monitor max( roleSlots( 'service:role', 'loadavg5' ) ) 15.70 > 10.00",
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/alerts_test.go
+++ b/alerts_test.go
@@ -45,6 +45,14 @@ func TestFormatJoinedAlert(t *testing.T) {
 			},
 			"2tZhm 1970-01-01 00:05:00 WARNING bar.baz monitor ServiceFoo custom.bar.baz 15.70 > 10.00",
 		},
+		{
+			&alertSet{
+				&mkr.Alert{ID: "2tZhm", Type: "external", Status: "CRITICAL", MonitorID: "5rXR3", Value: 2500, Message: "200", OpenedAt: 400},
+				nil,
+				&mkr.MonitorExternalHTTP{ID: "5rXR3", Type: "external", Name: "Example Domain", URL: "https://example.com", ResponseTimeWarning: 500, ResponseTimeCritical: 1000, ResponseTimeDuration: 5},
+			},
+			"2tZhm 1970-01-01 00:06:40 CRITICAL Example Domain https://example.com 2500.00 > 1000.00 msec, status:200",
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
This pull request adds support for expression monitor alerts. It prints the expression in the configuration, current value, operator and threshold.