### PR TITLE
[monitors diff] Add the "to-remote" bool flag

### DIFF
--- a/monitors.go
+++ b/monitors.go
@@ -43,7 +43,7 @@ var commandMonitors = cli.Command{
 			Flags: []cli.Flag{
 				cli.BoolFlag{Name: "exit-code, e", Usage: "Make mkr exit with code 1 if there are differences and 0 if there aren't. This is similar to diff(1)"},
 				cli.StringFlag{Name: "file-path, F", Value: "", Usage: "Filename to store monitor rule definitions. default: monitors.json"},
-				cli.BoolFlag{Name: "to-remote", Usage: "The difference on the remote server is represented by plus and the difference on the local file is represented by minus"},
+				cli.BoolFlag{Name: "invert-diff", Usage: "The difference on the remote server is represented by plus and the difference on the local file is represented by minus"},
 			},
 		},
 		{
@@ -387,12 +387,12 @@ func checkMonitorsDiff(c *cli.Context) monitorDiff {
 func doMonitorsDiff(c *cli.Context) error {
 	monitorDiff := checkMonitorsDiff(c)
 	isExitCode := c.Bool("exit-code")
-	isToRemote := c.Bool("to-remote")
+	isInvertedDiff := c.Bool("invert-diff")
 
 	var diffs []string
 	for _, d := range monitorDiff.diff {
 		var diff string
-		if isToRemote {
+		if isInvertedDiff {
 			diff = diffMonitor(d.local, d.remote)
 		} else {
 			diff = diffMonitor(d.remote, d.local)
@@ -402,7 +402,7 @@ func doMonitorsDiff(c *cli.Context) error {
 
 	var monitorOnlyFrom []mkr.Monitor
 	var monitorOnlyTo []mkr.Monitor
-	if isToRemote {
+	if isInvertedDiff {
 		monitorOnlyFrom = monitorDiff.onlyLocal
 		monitorOnlyTo = monitorDiff.onlyRemote
 	} else {

--- a/monitors.go
+++ b/monitors.go
@@ -43,7 +43,7 @@ var commandMonitors = cli.Command{
 			Flags: []cli.Flag{
 				cli.BoolFlag{Name: "exit-code, e", Usage: "Make mkr exit with code 1 if there are differences and 0 if there aren't. This is similar to diff(1)"},
 				cli.StringFlag{Name: "file-path, F", Value: "", Usage: "Filename to store monitor rule definitions. default: monitors.json"},
-				cli.BoolFlag{Name: "invert-diff", Usage: "The difference on the remote server is represented by plus and the difference on the local file is represented by minus"},
+				cli.BoolFlag{Name: "reverse", Usage: "The difference on the remote server is represented by plus and the difference on the local file is represented by minus"},
 			},
 		},
 		{
@@ -387,12 +387,12 @@ func checkMonitorsDiff(c *cli.Context) monitorDiff {
 func doMonitorsDiff(c *cli.Context) error {
 	monitorDiff := checkMonitorsDiff(c)
 	isExitCode := c.Bool("exit-code")
-	isInvertedDiff := c.Bool("invert-diff")
+	isReverse := c.Bool("reverse")
 
 	var diffs []string
 	for _, d := range monitorDiff.diff {
 		var diff string
-		if isInvertedDiff {
+		if isReverse {
 			diff = diffMonitor(d.local, d.remote)
 		} else {
 			diff = diffMonitor(d.remote, d.local)
@@ -402,7 +402,7 @@ func doMonitorsDiff(c *cli.Context) error {
 
 	var monitorOnlyFrom []mkr.Monitor
 	var monitorOnlyTo []mkr.Monitor
-	if isInvertedDiff {
+	if isReverse {
 		monitorOnlyFrom = monitorDiff.onlyLocal
 		monitorOnlyTo = monitorDiff.onlyRemote
 	} else {

--- a/monitors.go
+++ b/monitors.go
@@ -43,6 +43,7 @@ var commandMonitors = cli.Command{
 			Flags: []cli.Flag{
 				cli.BoolFlag{Name: "exit-code, e", Usage: "Make mkr exit with code 1 if there are differences and 0 if there aren't. This is similar to diff(1)"},
 				cli.StringFlag{Name: "file-path, F", Value: "", Usage: "Filename to store monitor rule definitions. default: monitors.json"},
+				cli.BoolFlag{Name: "to-remote", Usage: "The difference on the remote server is represented by plus and the difference on the local file is represented by minus"},
 			},
 		},
 		{
@@ -386,23 +387,40 @@ func checkMonitorsDiff(c *cli.Context) monitorDiff {
 func doMonitorsDiff(c *cli.Context) error {
 	monitorDiff := checkMonitorsDiff(c)
 	isExitCode := c.Bool("exit-code")
+	isToRemote := c.Bool("to-remote")
 
 	var diffs []string
 	for _, d := range monitorDiff.diff {
-		diffs = append(diffs, diffMonitor(d.remote, d.local))
+		var diff string
+		if isToRemote {
+			diff = diffMonitor(d.local, d.remote)
+		} else {
+			diff = diffMonitor(d.remote, d.local)
+		}
+		diffs = append(diffs, diff)
 	}
 
-	fmt.Printf("Summary: %d modify, %d append, %d remove\n\n", len(monitorDiff.diff), len(monitorDiff.onlyLocal), len(monitorDiff.onlyRemote))
+	var monitorOnlyFrom []mkr.Monitor
+	var monitorOnlyTo []mkr.Monitor
+	if isToRemote {
+		monitorOnlyFrom = monitorDiff.onlyLocal
+		monitorOnlyTo = monitorDiff.onlyRemote
+	} else {
+		monitorOnlyFrom = monitorDiff.onlyRemote
+		monitorOnlyTo = monitorDiff.onlyLocal
+	}
+
+	fmt.Printf("Summary: %d modify, %d append, %d remove\n\n", len(monitorDiff.diff), len(monitorOnlyTo), len(monitorOnlyFrom))
 	noDiff := true
 	for _, diff := range diffs {
 		fmt.Println(diff)
 		noDiff = false
 	}
-	for _, m := range monitorDiff.onlyRemote {
+	for _, m := range monitorOnlyFrom {
 		fmt.Println(stringifyMonitor(m, "-"))
 		noDiff = false
 	}
-	for _, m := range monitorDiff.onlyLocal {
+	for _, m := range monitorOnlyTo {
 		fmt.Println(stringifyMonitor(m, "+"))
 		noDiff = false
 	}


### PR DESCRIPTION
We are running `mkr monitors diff` to capture the difference by the GUI.

- ref. http://arata.hatenadiary.com/entry/2016/12/11/090000

Current output consists of the difference on the remote server represented by minus and the difference on the local file represented by plus. 
This is useful for the use case that run`mkr monitors push` afterwards. 

However if you run `mkr monitor pull` after `mkr monitor diff`, it is more useful to invert the output and the current one confuses us.