### PR TITLE
Improve help management and fix usage help for command

### DIFF
--- a/alerts.go
+++ b/alerts.go
@@ -23,10 +23,13 @@ var commandAlerts = cli.Command{
 	Action: doAlertsRetrieve,
 	Subcommands: []cli.Command{
 		{
-			Name:        "list",
-			Usage:       "list alerts",
-			Description: "Shows alerts in human-readable format.",
-			Action:      doAlertsList,
+			Name:      "list",
+			Usage:     "list alerts",
+			ArgsUsage: "[--service | -s <service>] [--host-status | -S <file>] [--color | -c]",
+			Description: `
+    Shows alerts in human-readable format.
+`,
+			Action: doAlertsList,
 			Flags: []cli.Flag{
 				cli.StringSliceFlag{
 					Name:  "service, s",
@@ -42,10 +45,13 @@ var commandAlerts = cli.Command{
 			},
 		},
 		{
-			Name:        "close",
-			Usage:       "close alerts",
-			Description: "Closes alerts. Multiple alert IDs can be specified.",
-			Action:      doAlertsClose,
+			Name:      "close",
+			Usage:     "close alerts",
+			ArgsUsage: "<alertIds....>",
+			Description: `
+    Closes alerts. Multiple alert IDs can be specified.
+`,
+			Action: doAlertsClose,
 			Flags: []cli.Flag{
 				cli.StringFlag{Name: "reason, r", Value: "", Usage: "Reason of closing alert."},
 				cli.BoolFlag{Name: "verbose, v", Usage: "Verbose output mode"},

--- a/commands.go
+++ b/commands.go
@@ -15,6 +15,24 @@ import (
 	"gopkg.in/urfave/cli.v1"
 )
 
+func init() {
+	// Requirements:
+	// - .Description: First and last line is blank.
+	// - .ArgsUsage: ArgsUsage includes flag usages (e.g. [-v|verbose] <hostId>).
+	//   All cli.Command should have ArgsUsage field.
+	cli.CommandHelpTemplate = `NAME:
+   {{.HelpName}} - {{.Usage}}
+
+USAGE:
+   {{.HelpName}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{if .Description}}
+
+DESCRIPTION:{{.Description}}{{end}}{{if .VisibleFlags}}
+OPTIONS:
+   {{range .VisibleFlags}}{{.}}
+   {{end}}{{end}}
+`
+}
+
 // Commands cli.Command object list
 var Commands = []cli.Command{
 	commandStatus,
@@ -30,8 +48,9 @@ var Commands = []cli.Command{
 }
 
 var commandStatus = cli.Command{
-	Name:  "status",
-	Usage: "Show the host",
+	Name:      "status",
+	Usage:     "Show the host",
+	ArgsUsage: "[--verbose | -v] <hostId>",
 	Description: `
     Show the information of the host identified with <hostId>.
     Requests "GET /api/v0/hosts/<hostId>". See https://mackerel.io/api-docs/entry/hosts#get .
@@ -43,8 +62,9 @@ var commandStatus = cli.Command{
 }
 
 var commandHosts = cli.Command{
-	Name:  "hosts",
-	Usage: "List hosts",
+	Name:      "hosts",
+	Usage:     "List hosts",
+	ArgsUsage: "[--verbose | -v] [--name | -n <name>] [--service | -s <service>] [[--role | -r <role>]...] [[--status | --st <status>]...]",
 	Description: `
     List the information of the hosts refined by host name, service name, role name and/or status.
     Requests "GET /api/v0/hosts.json". See https://mackerel.io/api-docs/entry/hosts#list .
@@ -69,8 +89,9 @@ var commandHosts = cli.Command{
 }
 
 var commandCreate = cli.Command{
-	Name:  "create",
-	Usage: "Create a new host",
+	Name:      "create",
+	Usage:     "Create a new host",
+	ArgsUsage: "[--status | -st <status>] [--roleFullname | -R <service:role>] <hostName>",
 	Description: `
     Create a new host with status and/or roleFullname.
     Requests "POST /api/v0/hosts". See https://mackerel.io/api-docs/entry/hosts#create .
@@ -87,8 +108,9 @@ var commandCreate = cli.Command{
 }
 
 var commandUpdate = cli.Command{
-	Name:  "update",
-	Usage: "Update the host",
+	Name:      "update",
+	Usage:     "Update the host",
+	ArgsUsage: "[--name | -n <name>] [--displayName <displayName>] [--status | -st <status>] [--roleFullname | -R <service:role>] [--overwriteRoles | -o] [<hostIds...>]",
 	Description: `
     Update the host identified with <hostId>.
     Requests "PUT /api/v0/hosts/<hostId>". See https://mackerel.io/api-docs/entry/hosts#update-information .
@@ -108,8 +130,9 @@ var commandUpdate = cli.Command{
 }
 
 var commandThrow = cli.Command{
-	Name:  "throw",
-	Usage: "Post metric values",
+	Name:      "throw",
+	Usage:     "Post metric values",
+	ArgsUsage: "[--host | -h <hostId>] [--service | -s <service>] stdin",
 	Description: `
     Post metric values to 'host metric' or 'service metric'.
     Output format of metric values are compatible with that of a Sensu plugin.
@@ -123,8 +146,9 @@ var commandThrow = cli.Command{
 }
 
 var commandFetch = cli.Command{
-	Name:  "fetch",
-	Usage: "Fetch latest metric values",
+	Name:      "fetch",
+	Usage:     "Fetch latest metric values",
+	ArgsUsage: "[--name | -n <metricName>] hostIds...",
 	Description: `
     Fetch latest metric values about the hosts.
     Requests "GET /api/v0/tsdb/latest". See https://mackerel.io/api-docs/entry/host-metrics#get-latest .
@@ -140,8 +164,9 @@ var commandFetch = cli.Command{
 }
 
 var commandRetire = cli.Command{
-	Name:  "retire",
-	Usage: "Retire hosts",
+	Name:      "retire",
+	Usage:     "Retire hosts",
+	ArgsUsage: "[--force] hostIds...",
 	Description: `
     Retire host identified by <hostId>. Be careful because this is an irreversible operation.
     Requests POST /api/v0/hosts/<hostId>/retire parallelly. See https://mackerel.io/api-docs/entry/hosts#retire .
@@ -183,59 +208,6 @@ func newMackerelFromContext(c *cli.Context) *mkr.Client {
 	logger.DieIf(err)
 
 	return mackerel
-}
-
-type commandDoc struct {
-	Parent    string
-	Arguments string
-}
-
-var commandDocs = map[string]commandDoc{
-	"status":     {"", "[-v|verbose] <hostId>"},
-	"hosts":      {"", "[--verbose | -v] [--name | -n <name>] [--service | -s <service>] [[--role | -r <role>]...] [[--status | --st <status>]...]"},
-	"create":     {"", "[--status | -st <status>] [--roleFullname | -R <service:role>] <hostName>"},
-	"update":     {"", "[--name | -n <name>] [--displayName <displayName>] [--status | -st <status>] [--roleFullname | -R <service:role>] <hostIds...> ]"},
-	"throw":      {"", "[--host | -h <hostId>] [--service | -s <service>] stdin"},
-	"fetch":      {"", "[--name | -n <metricName>] hostIds..."},
-	"retire":     {"", "hostIds..."},
-	"monitors":   {"", "[push [--dry-run | -d] [--file-path | -F <file>] [--verbose | -v] | diff [--file-path | -F <file>] | pull [--file-path | -F <file>]]"},
-	"alerts":     {"", "[list [--service | -s <service>] [--host-status | -S <file>] [--color | -c]| close <alertIds....>]"},
-	"dashboards": {"", "[generate <file> [--print | -p]]"},
-}
-
-// Makes template conditionals to generate per-command documents.
-func mkCommandsTemplate(genTemplate func(commandDoc) string) string {
-	template := "{{if false}}"
-	for _, command := range append(Commands) {
-		template = template + fmt.Sprintf("{{else if (eq .Name %q)}}%s", command.Name, genTemplate(commandDocs[command.Name]))
-	}
-	return template + "{{end}}"
-}
-
-func init() {
-	argsTemplate := mkCommandsTemplate(func(doc commandDoc) string { return doc.Arguments })
-	parentTemplate := mkCommandsTemplate(func(doc commandDoc) string { return string(strings.TrimLeft(doc.Parent+" ", " ")) })
-
-	cli.CommandHelpTemplate = `NAME:
-    {{.Name}} - {{.Usage}}
-
-USAGE:
-    mkr ` + parentTemplate + `{{.Name}} ` + argsTemplate + `
-{{if (len .Description)}}
-DESCRIPTION: {{.Description}}
-{{end}}{{if (len .Subcommands)}}
-COMMANDS:
-    {{range .Subcommands}}{{.Name}}
-      {{.Description}}{{if (len .Flags)}}
-
-        {{range .Flags}}{{.}}
-        {{end}}{{end}}
-    {{end}}
-{{end}}{{if (len .Flags)}}
-OPTIONS:
-    {{range .Flags}}{{.}}
-    {{end}}
-{{end}}`
 }
 
 func doStatus(c *cli.Context) error {

--- a/commands_test.go
+++ b/commands_test.go
@@ -26,13 +26,13 @@ func TestCommands_requirements(t *testing.T) {
 		if !strings.HasSuffix(c.Description, "\n") {
 			t.Errorf("%s: cli.Command.Description should end with '\\n', got:\n%s", c.Name, c.Description)
 		}
-		if c.ArgsUsage == "" {
-			t.Errorf("%s: cli.Command.ArgsUsage should not be empty", c.Name)
+		if len(c.Flags) > 0 && c.ArgsUsage == "" {
+			t.Errorf("%s: cli.Command.ArgsUsage should not be empty. Describe flag options.", c.Name)
 		}
 	}
 	for _, sc := range subcs {
 		if sc.Description == "" {
-			t.Error("%s: cli.Command.Description should not be empty", sc.Name)
+			t.Errorf("%s: cli.Command.Description should not be empty", sc.Name)
 		}
 	}
 }

--- a/commands_test.go
+++ b/commands_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/urfave/cli.v1"
+)
+
+func TestCommands_requirements(t *testing.T) {
+	var cs, subcs []cli.Command
+	for _, c := range Commands {
+		if len(c.Subcommands) == 0 {
+			cs = append(cs, c)
+		} else {
+			for _, sc := range c.Subcommands {
+				cs = append(cs, sc)
+			}
+			subcs = append(subcs, c)
+		}
+	}
+	for _, c := range cs {
+		if !strings.HasPrefix(c.Description, "\n    ") {
+			t.Errorf("%s: cli.Command.Description should start with '\\n    ', got:\n%s", c.Name, c.Description)
+		}
+		if !strings.HasSuffix(c.Description, "\n") {
+			t.Errorf("%s: cli.Command.Description should end with '\\n', got:\n%s", c.Name, c.Description)
+		}
+		if c.ArgsUsage == "" {
+			t.Errorf("%s: cli.Command.ArgsUsage should not be empty", c.Name)
+		}
+	}
+	for _, sc := range subcs {
+		if sc.Description == "" {
+			t.Error("%s: cli.Command.Description should not be empty", sc.Name)
+		}
+	}
+}

--- a/dashboards.go
+++ b/dashboards.go
@@ -15,6 +15,9 @@ import (
 
 var commandDashboards = cli.Command{
 	Name: "dashboards",
+	Description: `
+    Generating dashboards. See https://mackerel.io/docs/entry/advanced/cli
+`,
 	Subcommands: []cli.Command{
 		{
 			Name:      "generate",

--- a/dashboards.go
+++ b/dashboards.go
@@ -17,8 +17,9 @@ var commandDashboards = cli.Command{
 	Name: "dashboards",
 	Subcommands: []cli.Command{
 		{
-			Name:  "generate",
-			Usage: "Generate custom dashboard",
+			Name:      "generate",
+			Usage:     "Generate custom dashboard",
+			ArgsUsage: "[--print | -p] <file>",
 			Description: `
     A custom dashboard is registered from a yaml file.
     Requests "POST /api/v0/dashboards". See https://mackerel.io/ja/api-docs/entry/dashboards#create.

--- a/monitors.go
+++ b/monitors.go
@@ -26,20 +26,26 @@ var commandMonitors = cli.Command{
 	Action: doMonitorsList,
 	Subcommands: []cli.Command{
 		{
-			Name:        "pull",
-			Usage:       "pull rules",
-			Description: "Pull monitor rules from Mackerel server and save them to a file. The file can be specified by filepath argument <file>. The default is 'monitors.json'.",
-			Action:      doMonitorsPull,
+			Name:      "pull",
+			Usage:     "pull rules",
+			ArgsUsage: "[--file-path | -F <file>] [--verbose | -v]",
+			Description: `
+    Pull monitor rules from Mackerel server and save them to a file. The file can be specified by filepath argument <file>. The default is 'monitors.json'.
+`,
+			Action: doMonitorsPull,
 			Flags: []cli.Flag{
 				cli.StringFlag{Name: "file-path, F", Value: "", Usage: "Filename to store monitor rule definitions. default: monitors.json"},
 				cli.BoolFlag{Name: "verbose, v", Usage: "Verbose output mode"},
 			},
 		},
 		{
-			Name:        "diff",
-			Usage:       "diff rules",
-			Description: "Show difference of monitor rules between Mackerel and a file. The file can be specified by filepath argument <file>. The default is 'monitors.json'.",
-			Action:      doMonitorsDiff,
+			Name:  "diff",
+			Usage: "diff rules",
+			Description: `
+    Show difference of monitor rules between Mackerel and a file. The file can be specified by filepath argument <file>. The default is 'monitors.json'.
+`,
+			ArgsUsage: "[--file-path | -F <file>]",
+			Action:    doMonitorsDiff,
 			Flags: []cli.Flag{
 				cli.BoolFlag{Name: "exit-code, e", Usage: "Make mkr exit with code 1 if there are differences and 0 if there aren't. This is similar to diff(1)"},
 				cli.StringFlag{Name: "file-path, F", Value: "", Usage: "Filename to store monitor rule definitions. default: monitors.json"},
@@ -47,10 +53,13 @@ var commandMonitors = cli.Command{
 			},
 		},
 		{
-			Name:        "push",
-			Usage:       "push rules",
-			Description: "Push monitor rules stored in a file to Mackerel. The file can be specified by filepath argument <file>. The default is 'monitors.json'.",
-			Action:      doMonitorsPush,
+			Name:      "push",
+			Usage:     "push rules",
+			ArgsUsage: "[--dry-run | -d] [--file-path | -F <file>] [--verbose | -v]",
+			Description: `
+    Push monitor rules stored in a file to Mackerel. The file can be specified by filepath argument <file>. The default is 'monitors.json'.
+`,
+			Action: doMonitorsPush,
 			Flags: []cli.Flag{
 				cli.StringFlag{Name: "file-path, F", Value: "", Usage: "Filename to store monitor rule definitions. default: monitors.json"},
 				cli.BoolFlag{Name: "dry-run, d", Usage: "Show which apis are called, but not execute."},


### PR DESCRIPTION
`var commandDocs = map[string]commandDoc{...}` has worked to some
extent, but it didn't work with sub-sub commands.

e.g. $ mkr monitors diff -h shows wrong usage as following.

  USAGE:
      mkr diff

Old implementation seems to intend to enhance [Usage] document to show
available flags ([command options]).
commit: 064e51f5bd0d992b053e40474e93ddc269fceeb4

This commit use urfave/cli.Command.ArgsUsage field for [Usage] document.
godoc: https://godoc.org/github.com/urfave/cli#Command