### PR TITLE
remove unused functions

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"log"
 	"os"
 	"strconv"
 	"strings"
@@ -150,18 +149,6 @@ var commandRetire = cli.Command{
 	Flags: []cli.Flag{
 		cli.BoolFlag{Name: "force", Usage: "Force retirement without confirmation."},
 	},
-}
-
-func debug(v ...interface{}) {
-	if os.Getenv("DEBUG") != "" {
-		log.Println(v...)
-	}
-}
-
-func assert(err error) {
-	if err != nil {
-		log.Fatal(err)
-	}
 }
 
 func newMackerelFromContext(c *cli.Context) *mkr.Client {

--- a/monitors.go
+++ b/monitors.go
@@ -172,57 +172,6 @@ func doMonitorsPull(c *cli.Context) error {
 	return nil
 }
 
-func isEmpty(a interface{}) bool {
-	switch a.(type) {
-	case bool:
-		if reflect.ValueOf(a).Bool() == false {
-			return true
-		}
-	case int, int8, int16, int32, int64:
-		if reflect.ValueOf(a).Int() == 0 {
-			return true
-		}
-	case uint, uint8, uint16, uint32, uint64:
-		if reflect.ValueOf(a).Uint() == 0 {
-			return true
-		}
-	case float32, float64:
-		if reflect.ValueOf(a).Float() == 0.0 {
-			return true
-		}
-	case string:
-		if reflect.ValueOf(a).String() == "" {
-			return true
-		}
-	}
-	return false
-}
-
-func appendDiff(src []string, name string, a interface{}, b interface{}) []string {
-	diff := src
-	aType := reflect.TypeOf(a).String()
-	format := "\"%s\""
-	isAEmpty := isEmpty(a)
-	isBEmpty := isEmpty(b)
-	switch aType {
-	case "bool":
-		format = "%t"
-	case "uint64":
-		format = "%d"
-	case "float64":
-		format = "%f"
-	}
-	if isAEmpty == false || isBEmpty == false {
-		if a != b {
-			diff = append(diff, fmt.Sprintf("-   \"%s\": "+format+",", name, a))
-			diff = append(diff, fmt.Sprintf("+   \"%s\": "+format+",", name, b))
-		} else {
-			diff = append(diff, fmt.Sprintf("    \"%s\": "+format+",", name, a))
-		}
-	}
-	return diff
-}
-
 func stringifyMonitor(a mkr.Monitor, prefix string) string {
 	return prefix + JSONMarshalIndent(a, prefix, "  ") + ","
 }


### PR DESCRIPTION
appendDiff is unused since #75
isEmpty seems to exist for calculating monitor diff, but it's unused too.

I also remove 2 unused debug functions (debug, assert).

```
$ go get honnef.co/go/tools/cmd/unused
$ unused github.com/mackerelio/mkr
/home/haya14busa/src/github.com/mackerelio/mkr/commands.go:155:6: func debug is unused (U1000)
/home/haya14busa/src/github.com/mackerelio/mkr/commands.go:161:6: func assert is unused (U1000)
/home/haya14busa/src/github.com/mackerelio/mkr/monitors.go:175:6: func isEmpty is unused (U1000)
/home/haya14busa/src/github.com/mackerelio/mkr/monitors.go:201:6: func appendDiff is unused (U1000)
```
https://github.com/dominikh/go-tools/tree/master/cmd/unused