### PR TITLE
bump Go to 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.6.2
+- 1.8
 git:
   depth: 99999
 env:


### PR DESCRIPTION
Since https://github.com/akatu/github-release (release dependency) now requires go >= 1.7, our easiest solution is to bump go.
ref: https://travis-ci.org/mackerelio/mkr/builds/216646176 / https://github.com/aktau/github-release/commit/f2ebbf795aa4ab88b13c940c7df6807ce79c2b08
(`setIndent` is introduced on go 1.7: https://golang.org/doc/go1.7#encoding_json)