### PR TITLE
Add services subcommand

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -41,6 +41,7 @@ var Commands = []cli.Command{
 	commandThrow,
 	commandFetch,
 	commandRetire,
+	commandServices,
 	commandMonitors,
 	commandAlerts,
 	commandDashboards,
@@ -175,6 +176,18 @@ var commandRetire = cli.Command{
 	Flags: []cli.Flag{
 		cli.BoolFlag{Name: "force", Usage: "Force retirement without confirmation."},
 	},
+}
+
+var commandServices = cli.Command{
+	Name:      "services",
+	Usage:     "List services",
+	ArgsUsage: "",
+	Description: `
+    List the information of the services.
+    Requests "GET /api/v0/services". See https://mackerel.io/api-docs/entry/services#list.
+`,
+	Action: doServices,
+	Flags:  []cli.Flag{},
 }
 
 func newMackerelFromContext(c *cli.Context) *mkr.Client {
@@ -479,5 +492,12 @@ func doRetire(c *cli.Context) error {
 
 		logger.Log("retired", hostID)
 	}
+	return nil
+}
+
+func doServices(c *cli.Context) error {
+	services, err := newMackerelFromContext(c).FindServices()
+	logger.DieIf(err)
+	PrettyPrintJSON(services)
 	return nil
 }


### PR DESCRIPTION
This PR depends on https://github.com/mackerelio/mackerel-client-go/pull/44 .

```
$ mkr services -h
   mkr services - List services

USAGE:
   mkr services [arguments...]

DESCRIPTION:
    List the information of the services.
    Requests "GET /api/v0/services". See https://mackerel.io/api-docs/entry/services#list.
```