### PR TITLE
Prefer apibase in mackerel-agent confFile

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -202,7 +202,7 @@ func newMackerelFromContext(c *cli.Context) *mkr.Client {
 	}
 
 	if apiBase == "" {
-		apiBase = LoadApibaseFromConfig(confFile)
+		apiBase = LoadApibaseFromConfigWithFallback(confFile)
 	}
 
 	mackerel, err := mkr.NewClientWithOptions(apiKey, apiBase, os.Getenv("DEBUG") != "")

--- a/config.go
+++ b/config.go
@@ -31,6 +31,16 @@ func LoadApibaseFromConfig(conffile string) string {
 	return conf.Apibase
 }
 
+// LoadApibaseFromConfigWithFallback get mackerel api Base URL from mackerel-agent.conf,
+// and fallbacks to default (https://mackerel.io/) if not specified.
+func LoadApibaseFromConfigWithFallback(conffile string) string {
+	apiBase := LoadApibaseFromConfig(conffile)
+	if apiBase == "" {
+		return config.DefaultConfig.Apibase
+	}
+	return apiBase
+}
+
 // LoadApikeyFromConfig gets mackerel.io apikey from mackerel-agent.conf if it's installed mackerel-agent on localhost
 func LoadApikeyFromConfig(conffile string) string {
 	conf, err := config.LoadConfig(conffile)

--- a/config_test.go
+++ b/config_test.go
@@ -16,6 +16,22 @@ func TestLoadApibaseFromConfig(t *testing.T) {
 	}
 }
 
+func TestLoadApibaseFromConfigWithFallback(t *testing.T) {
+	conffile := "test/mackerel-agent.conf"
+
+	apiBase := LoadApibaseFromConfigWithFallback(conffile)
+
+	if apiBase != "https://example.com/" {
+		t.Error("should be https://example.com/")
+	}
+
+	apiBase = LoadApibaseFromConfigWithFallback("test/mackerel-agent-no-base.conf")
+
+	if apiBase != "https://mackerel.io" {
+		t.Error("should be https://mackerel.io")
+	}
+}
+
 func TestLoadApikeyFromConfig(t *testing.T) {
 	conffile := "test/mackerel-agent.conf"
 

--- a/mkr.go
+++ b/mkr.go
@@ -23,9 +23,9 @@ func main() {
 			Usage: "Config file path",
 		},
 		cli.StringFlag{
-			Name:  "apibase",
-			Value: config.DefaultConfig.Apibase,
-			Usage: "API Base",
+			Name: "apibase",
+			// this default value is set in config.LoadApibaseFromConfigWithFallback
+			Usage: fmt.Sprintf("API Base (default: \"%s\")", config.DefaultConfig.Apibase),
 		},
 	}
 

--- a/test/mackerel-agent-no-base.conf
+++ b/test/mackerel-agent-no-base.conf
@@ -1,0 +1,4 @@
+pidfile = "./pid"
+root = "./test"
+verbose = false
+apikey = "ABCD123456"


### PR DESCRIPTION
I'm not sure this is the best……

## Priority

- If `-apibase` option is specified, it will be used
- If `-apibase` is not specified but `apibase` is specified in mackerel-agent configuration file, it will be used (NEW!!)
- When neither of them are present, default (mackerel.io) will be used