### PR TITLE
Check install target string more strictly

### DIFF
--- a/plugin/commands.go
+++ b/plugin/commands.go
@@ -46,7 +46,7 @@ func doPluginInstall(c *cli.Context) error {
 		return fmt.Errorf("Specify install target")
 	}
 
-	it, err := parseInstallTarget(argInstallTarget)
+	it, err := newInstallTargetFromString(argInstallTarget)
 	if err != nil {
 		return errors.Wrap(err, "Failed to install plugin while setup plugin directory")
 	}
@@ -79,40 +79,6 @@ func doPluginInstall(c *cli.Context) error {
 
 	logger.Log("", fmt.Sprintf("Successfully installed %s", argInstallTarget))
 	return nil
-}
-
-// Parse install target string passed from args
-// example is below
-// - mackerelio/mackerel-plugin-sample
-// - mackerel-plugin-sample
-// - mackerelio/mackerel-plugin-sample@v0.0.1
-func parseInstallTarget(target string) (*installTarget, error) {
-	it := &installTarget{}
-
-	ownerRepoAndReleaseTag := strings.Split(target, "@")
-	var ownerRepo string
-	switch len(ownerRepoAndReleaseTag) {
-	case 1:
-		ownerRepo = ownerRepoAndReleaseTag[0]
-	case 2:
-		ownerRepo = ownerRepoAndReleaseTag[0]
-		it.releaseTag = ownerRepoAndReleaseTag[1]
-	default:
-		return nil, fmt.Errorf("Install target is invalid: %s", target)
-	}
-
-	ownerAndRepo := strings.Split(ownerRepo, "/")
-	switch len(ownerAndRepo) {
-	case 1:
-		it.pluginName = ownerAndRepo[0]
-	case 2:
-		it.owner = ownerAndRepo[0]
-		it.repo = ownerAndRepo[1]
-	default:
-		return nil, fmt.Errorf("Install target is invalid: %s", target)
-	}
-
-	return it, nil
 }
 
 // Create a directory for plugin install
@@ -218,6 +184,40 @@ type installTarget struct {
 	repo       string
 	pluginName string
 	releaseTag string
+}
+
+// Parse install target string, and construct installTarget
+// example is below
+// - mackerelio/mackerel-plugin-sample
+// - mackerel-plugin-sample
+// - mackerelio/mackerel-plugin-sample@v0.0.1
+func newInstallTargetFromString(target string) (*installTarget, error) {
+	it := &installTarget{}
+
+	ownerRepoAndReleaseTag := strings.Split(target, "@")
+	var ownerRepo string
+	switch len(ownerRepoAndReleaseTag) {
+	case 1:
+		ownerRepo = ownerRepoAndReleaseTag[0]
+	case 2:
+		ownerRepo = ownerRepoAndReleaseTag[0]
+		it.releaseTag = ownerRepoAndReleaseTag[1]
+	default:
+		return nil, fmt.Errorf("Install target is invalid: %s", target)
+	}
+
+	ownerAndRepo := strings.Split(ownerRepo, "/")
+	switch len(ownerAndRepo) {
+	case 1:
+		it.pluginName = ownerAndRepo[0]
+	case 2:
+		it.owner = ownerAndRepo[0]
+		it.repo = ownerAndRepo[1]
+	default:
+		return nil, fmt.Errorf("Install target is invalid: %s", target)
+	}
+
+	return it, nil
 }
 
 // Make artifact's download URL

--- a/plugin/commands.go
+++ b/plugin/commands.go
@@ -49,12 +49,12 @@ func doPluginInstall(c *cli.Context) error {
 
 	it, err := newInstallTargetFromString(argInstallTarget)
 	if err != nil {
-		return errors.Wrap(err, "Failed to install plugin while setup plugin directory")
+		return errors.Wrap(err, "Failed to install plugin while parsing install target")
 	}
 
 	pluginDir, err := setupPluginDir(c.String("prefix"))
 	if err != nil {
-		return errors.Wrap(err, "Failed to install plugin while parsing install target")
+		return errors.Wrap(err, "Failed to install plugin while setup plugin directory")
 	}
 
 	// Create a work directory for downloading and extracting an artifact

--- a/plugin/commands_test.go
+++ b/plugin/commands_test.go
@@ -229,12 +229,21 @@ func TestNewInstallTargetFromString(t *testing.T) {
 				releaseTag: "v1.0.1",
 			},
 		},
+		{
+			Name:  "Owner and repo with release tag(which has / and @)",
+			Input: "mackerelio/mackerel-plugin-sample@v1.0.1/hoge@fuga",
+			Output: installTarget{
+				owner:      "mackerelio",
+				repo:       "mackerel-plugin-sample",
+				releaseTag: "v1.0.1/hoge@fuga",
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Logf("testing: %s\n", tc.Name)
 		it, err := newInstallTargetFromString(tc.Input)
-		assert.Nil(t, err, "error does not occur while parseInstallTarget")
+		assert.Nil(t, err, "error does not occur while newInstallTargetFromString")
 		assert.Equal(t, tc.Output, *it, "Parsing result is expected")
 	}
 }
@@ -246,21 +255,41 @@ func TestNewInstallTargetFromString_error(t *testing.T) {
 		Output string
 	}{
 		{
-			Name:   "Too many @",
-			Input:  "mackerel-plugin-sample@v0.0.1@v0.1.0",
-			Output: "Install target is invalid: mackerel-plugin-sample@v0.0.1@v0.1.0",
+			Name:   "Empty String",
+			Input:  "",
+			Output: "Install target is invalid: ",
 		},
 		{
 			Name:   "Too many /",
 			Input:  "mackerelio/hatena/mackerel-plugin-sample",
 			Output: "Install target is invalid: mackerelio/hatena/mackerel-plugin-sample",
 		},
+		{
+			Name:   "End with /",
+			Input:  "mackerelio/",
+			Output: "Install target is invalid: mackerelio/",
+		},
+		{
+			Name:   "Start with /",
+			Input:  "/mackerel-plugin-sample",
+			Output: "Install target is invalid: /mackerel-plugin-sample",
+		},
+		{
+			Name:   "Only release tag",
+			Input:  "@v0.0.1",
+			Output: "Install target is invalid: @v0.0.1",
+		},
+		{
+			Name:   "End with @",
+			Input:  "hoge/fuga@",
+			Output: "Install target is invalid: hoge/fuga@",
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Logf("testing: %s\n", tc.Name)
 		_, err := newInstallTargetFromString(tc.Input)
-		assert.NotNil(t, err, "parseInstallTarget returns err when invalid target string is passed")
+		assert.NotNil(t, err, "newInstallTargetFromString returns err when invalid target string is passed")
 		assert.Equal(t, tc.Output, err.Error(), "error message is expected")
 	}
 }

--- a/plugin/commands_test.go
+++ b/plugin/commands_test.go
@@ -33,80 +33,6 @@ func assertEqualFileContent(t *testing.T, aFile, bFile, message string) {
 	assert.Equal(t, aContent, bContent, message)
 }
 
-func TestParseInstallTarget(t *testing.T) {
-	testCases := []struct {
-		Name   string
-		Input  string
-		Output installTarget
-	}{
-		{
-			Name:  "Plugin name only",
-			Input: "mackerel-plugin-sample",
-			Output: installTarget{
-				pluginName: "mackerel-plugin-sample",
-			},
-		},
-		{
-			Name:  "Plugin name and release tag",
-			Input: "mackerel-plugin-sample@v0.0.1",
-			Output: installTarget{
-				pluginName: "mackerel-plugin-sample",
-				releaseTag: "v0.0.1",
-			},
-		},
-		{
-			Name:  "Owner and repo",
-			Input: "mackerelio/mackerel-plugin-sample",
-			Output: installTarget{
-				owner: "mackerelio",
-				repo:  "mackerel-plugin-sample",
-			},
-		},
-		{
-			Name:  "Owner and repo with release tag",
-			Input: "mackerelio/mackerel-plugin-sample@v1.0.1",
-			Output: installTarget{
-				owner:      "mackerelio",
-				repo:       "mackerel-plugin-sample",
-				releaseTag: "v1.0.1",
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Logf("testing: %s\n", tc.Name)
-		it, err := parseInstallTarget(tc.Input)
-		assert.Nil(t, err, "error does not occur while parseInstallTarget")
-		assert.Equal(t, tc.Output, *it, "Parsing result is expected")
-	}
-}
-
-func TestParseInstallTarget_error(t *testing.T) {
-	testCases := []struct {
-		Name   string
-		Input  string
-		Output string
-	}{
-		{
-			Name:   "Too many @",
-			Input:  "mackerel-plugin-sample@v0.0.1@v0.1.0",
-			Output: "Install target is invalid: mackerel-plugin-sample@v0.0.1@v0.1.0",
-		},
-		{
-			Name:   "Too many /",
-			Input:  "mackerelio/hatena/mackerel-plugin-sample",
-			Output: "Install target is invalid: mackerelio/hatena/mackerel-plugin-sample",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Logf("testing: %s\n", tc.Name)
-		_, err := parseInstallTarget(tc.Input)
-		assert.NotNil(t, err, "parseInstallTarget returns err when invalid target string is passed")
-		assert.Equal(t, tc.Output, err.Error(), "error message is expected")
-	}
-}
-
 func TestSetupPluginDir(t *testing.T) {
 	{
 		// Creating plugin dir is successful
@@ -262,6 +188,80 @@ func TestLooksLikePlugin(t *testing.T) {
 
 	for _, tc := range testCases {
 		assert.Equal(t, tc.LooksLikePlugin, looksLikePlugin(tc.Name))
+	}
+}
+
+func TestNewInstallTargetFromString(t *testing.T) {
+	testCases := []struct {
+		Name   string
+		Input  string
+		Output installTarget
+	}{
+		{
+			Name:  "Plugin name only",
+			Input: "mackerel-plugin-sample",
+			Output: installTarget{
+				pluginName: "mackerel-plugin-sample",
+			},
+		},
+		{
+			Name:  "Plugin name and release tag",
+			Input: "mackerel-plugin-sample@v0.0.1",
+			Output: installTarget{
+				pluginName: "mackerel-plugin-sample",
+				releaseTag: "v0.0.1",
+			},
+		},
+		{
+			Name:  "Owner and repo",
+			Input: "mackerelio/mackerel-plugin-sample",
+			Output: installTarget{
+				owner: "mackerelio",
+				repo:  "mackerel-plugin-sample",
+			},
+		},
+		{
+			Name:  "Owner and repo with release tag",
+			Input: "mackerelio/mackerel-plugin-sample@v1.0.1",
+			Output: installTarget{
+				owner:      "mackerelio",
+				repo:       "mackerel-plugin-sample",
+				releaseTag: "v1.0.1",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Logf("testing: %s\n", tc.Name)
+		it, err := newInstallTargetFromString(tc.Input)
+		assert.Nil(t, err, "error does not occur while parseInstallTarget")
+		assert.Equal(t, tc.Output, *it, "Parsing result is expected")
+	}
+}
+
+func TestNewInstallTargetFromString_error(t *testing.T) {
+	testCases := []struct {
+		Name   string
+		Input  string
+		Output string
+	}{
+		{
+			Name:   "Too many @",
+			Input:  "mackerel-plugin-sample@v0.0.1@v0.1.0",
+			Output: "Install target is invalid: mackerel-plugin-sample@v0.0.1@v0.1.0",
+		},
+		{
+			Name:   "Too many /",
+			Input:  "mackerelio/hatena/mackerel-plugin-sample",
+			Output: "Install target is invalid: mackerelio/hatena/mackerel-plugin-sample",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Logf("testing: %s\n", tc.Name)
+		_, err := newInstallTargetFromString(tc.Input)
+		assert.NotNil(t, err, "parseInstallTarget returns err when invalid target string is passed")
+		assert.Equal(t, tc.Output, err.Error(), "error message is expected")
 	}
 }
 


### PR DESCRIPTION
This pull request does

- Rename parseInstallTarget to newInstallTargetFromString
    - because it is a kind of constructor of installTarget
- Parse install target string more strictly

## Parse install target string more strictly
Before, parseInstallTarget is success unexpectedly if target string is

- `mackerelio/`
- `/sample-plugin`
- `mackerel/io/plugin`

And parseInstallTarget is failed unexpectedly if target string is

- `mackerelio/mackerel-plugin-sample@release/0.0.1`
    - `release/0.0.1` can be specified as git tag name

So I fixed it.

# Note for reviewer
The diff is big because I move a method down.  I recommend a reviewer to watch one by one commit.