### PR TITLE
Install a plugin from latest Github Releases

### DIFF
--- a/plugin/commands.go
+++ b/plugin/commands.go
@@ -15,7 +15,6 @@ import (
 
 	"net/url"
 
-	"github.com/google/go-github/github"
 	"github.com/mackerelio/mkr/logger"
 	"github.com/mholt/archiver"
 	"github.com/pkg/errors"
@@ -279,7 +278,7 @@ func (it *installTarget) getReleaseTag(owner, repo string) (string, error) {
 
 	// Get latest release tag from Github API
 	ctx := context.Background()
-	client := github.NewClient(nil)
+	client := getGithubClient(ctx)
 	client.BaseURL = it.getGithubAPIURL()
 
 	release, _, err := client.Repositories.GetLatestRelease(ctx, owner, repo)

--- a/plugin/commands.go
+++ b/plugin/commands.go
@@ -180,12 +180,12 @@ type installTarget struct {
 	pluginName   string
 	releaseTag   string
 	rawGithubURL string
-	githubAPIURL string
+	apiGithubURL string
 }
 
 const (
 	defaultRawGithubURL = "https://raw.githubusercontent.com"
-	defaultGithubAPIURL = "https://api.github.com"
+	defaultAPIGithubURL = "https://api.github.com"
 )
 
 // the pattern of installTarget string
@@ -279,7 +279,7 @@ func (it *installTarget) getReleaseTag(owner, repo string) (string, error) {
 	// Get latest release tag from Github API
 	ctx := context.Background()
 	client := getGithubClient(ctx)
-	client.BaseURL = it.getGithubAPIURL()
+	client.BaseURL = it.getAPIGithubURL()
 
 	release, _, err := client.Repositories.GetLatestRelease(ctx, owner, repo)
 	if err != nil {
@@ -299,12 +299,12 @@ func (it *installTarget) getRawGithubURL() string {
 }
 
 // Returns URL object which Github Client.BaseURL can receive as it is
-func (it *installTarget) getGithubAPIURL() *url.URL {
-	u := defaultGithubAPIURL
-	if it.githubAPIURL != "" {
-		u = it.githubAPIURL
+func (it *installTarget) getAPIGithubURL() *url.URL {
+	u := defaultAPIGithubURL
+	if it.apiGithubURL != "" {
+		u = it.apiGithubURL
 	}
-	// Ignore err because githubAPIURL is specified only internally
+	// Ignore err because apiGithubURL is specified only internally
 	apiURL, _ := url.Parse(u + "/") // trailing `/` is required for BaseURL
 	return apiURL
 }

--- a/plugin/commands.go
+++ b/plugin/commands.go
@@ -220,9 +220,9 @@ func (it *installTarget) makeDownloadURL() (string, error) {
 		return "", err
 	}
 
-	if it.releaseTag == "" {
-		// TODO: Fetch latest release tag by github API
-		return "", fmt.Errorf("not implemented")
+	releaseTag, err := it.getReleaseTag(owner, repo)
+	if err != nil {
+		return "", err
 	}
 
 	filename := fmt.Sprintf("%s_%s_%s.zip", url.PathEscape(repo), runtime.GOOS, runtime.GOARCH)
@@ -230,7 +230,7 @@ func (it *installTarget) makeDownloadURL() (string, error) {
 		"https://github.com/%s/%s/releases/download/%s/%s",
 		url.PathEscape(owner),
 		url.PathEscape(repo),
-		url.PathEscape(it.releaseTag),
+		url.PathEscape(releaseTag),
 		filename,
 	)
 

--- a/plugin/commands.go
+++ b/plugin/commands.go
@@ -175,10 +175,12 @@ func placePlugin(src, dest string) error {
 }
 
 type installTarget struct {
-	owner        string
-	repo         string
-	pluginName   string
-	releaseTag   string
+	owner      string
+	repo       string
+	pluginName string
+	releaseTag string
+
+	// fields for testing
 	rawGithubURL string
 	apiGithubURL string
 }

--- a/plugin/commands_test.go
+++ b/plugin/commands_test.go
@@ -202,46 +202,41 @@ func TestNewInstallTargetFromString(t *testing.T) {
 			Name:  "Plugin name only",
 			Input: "mackerel-plugin-sample",
 			Output: installTarget{
-				pluginName:   "mackerel-plugin-sample",
-				rawGithubURL: defaultRawGithubURL,
+				pluginName: "mackerel-plugin-sample",
 			},
 		},
 		{
 			Name:  "Plugin name and release tag",
 			Input: "mackerel-plugin-sample@v0.0.1",
 			Output: installTarget{
-				pluginName:   "mackerel-plugin-sample",
-				releaseTag:   "v0.0.1",
-				rawGithubURL: defaultRawGithubURL,
+				pluginName: "mackerel-plugin-sample",
+				releaseTag: "v0.0.1",
 			},
 		},
 		{
 			Name:  "Owner and repo",
 			Input: "mackerelio/mackerel-plugin-sample",
 			Output: installTarget{
-				owner:        "mackerelio",
-				repo:         "mackerel-plugin-sample",
-				rawGithubURL: defaultRawGithubURL,
+				owner: "mackerelio",
+				repo:  "mackerel-plugin-sample",
 			},
 		},
 		{
 			Name:  "Owner and repo with release tag",
 			Input: "mackerelio/mackerel-plugin-sample@v1.0.1",
 			Output: installTarget{
-				owner:        "mackerelio",
-				repo:         "mackerel-plugin-sample",
-				releaseTag:   "v1.0.1",
-				rawGithubURL: defaultRawGithubURL,
+				owner:      "mackerelio",
+				repo:       "mackerel-plugin-sample",
+				releaseTag: "v1.0.1",
 			},
 		},
 		{
 			Name:  "Owner and repo with release tag(which has / and @)",
 			Input: "mackerelio/mackerel-plugin-sample@v1.0.1/hoge@fuga",
 			Output: installTarget{
-				owner:        "mackerelio",
-				repo:         "mackerel-plugin-sample",
-				releaseTag:   "v1.0.1/hoge@fuga",
-				rawGithubURL: defaultRawGithubURL,
+				owner:      "mackerelio",
+				repo:       "mackerel-plugin-sample",
+				releaseTag: "v1.0.1/hoge@fuga",
 			},
 		},
 	}
@@ -442,4 +437,20 @@ func TestInstallTargetGetOwnerAndRepo(t *testing.T) {
 		assert.Equal(t, "mackerelio", it.owner, "owner is cached")
 		assert.Equal(t, "mackerel-plugin-sample", it.repo, "repo is cached")
 	}
+}
+
+func TestInstallTargetGetRawGithubURL(t *testing.T) {
+	it := &installTarget{}
+	assert.Equal(t, "https://raw.githubusercontent.com", it.getRawGithubURL(), "Returns default URL")
+
+	it = &installTarget{rawGithubURL: "https://example.com"}
+	assert.Equal(t, "https://example.com", it.getRawGithubURL(), "Returns customized URL")
+}
+
+func TestInstallTargetGetGithubAPIURL(t *testing.T) {
+	it := &installTarget{}
+	assert.Equal(t, "https://api.github.com/", it.getGithubAPIURL().String(), "Returns default URL")
+
+	it = &installTarget{githubAPIURL: "https://api.example.com"}
+	assert.Equal(t, "https://api.example.com/", it.getGithubAPIURL().String(), "Returns customized URL")
 }

--- a/plugin/commands_test.go
+++ b/plugin/commands_test.go
@@ -356,13 +356,13 @@ func TestInstallTargetMakeDownloadURL(t *testing.T) {
 		mux.HandleFunc("/repos/owner1/check-repo1/releases/latest", func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, `{"tag_name": "1.01"}`)
 		})
-		githubAPIServer := httptest.NewServer(mux)
-		defer githubAPIServer.Close()
+		apiGithubServer := httptest.NewServer(mux)
+		defer apiGithubServer.Close()
 
 		it := &installTarget{
 			owner:        "owner1",
 			repo:         "check-repo1",
-			githubAPIURL: githubAPIServer.URL,
+			apiGithubURL: apiGithubServer.URL,
 		}
 		url, err := it.makeDownloadURL()
 		assert.NoError(t, err, "makeDownloadURL is successful")
@@ -377,7 +377,7 @@ func TestInstallTargetMakeDownloadURL(t *testing.T) {
 		it = &installTarget{
 			owner:        "owner1",
 			repo:         "check-not-found",
-			githubAPIURL: githubAPIServer.URL,
+			apiGithubURL: apiGithubServer.URL,
 		}
 		_, err = it.makeDownloadURL()
 		assert.Error(t, err, "makeDownloadURL is failed")
@@ -389,8 +389,8 @@ func TestInstallTargetMakeDownloadURL(t *testing.T) {
 		muxAPI.HandleFunc("/repos/owner1/mackerel-plugin-repo1/releases/latest", func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, `{"tag_name": "release/v0.5.1"}`)
 		})
-		githubAPIServer := httptest.NewServer(muxAPI)
-		defer githubAPIServer.Close()
+		apiGithubServer := httptest.NewServer(muxAPI)
+		defer apiGithubServer.Close()
 
 		muxRaw := http.NewServeMux()
 		muxRaw.HandleFunc(
@@ -404,7 +404,7 @@ func TestInstallTargetMakeDownloadURL(t *testing.T) {
 
 		it := &installTarget{
 			pluginName:   "mackerel-plugin-repo1",
-			githubAPIURL: githubAPIServer.URL,
+			apiGithubURL: apiGithubServer.URL,
 			rawGithubURL: rawGithubServer.URL,
 		}
 
@@ -527,7 +527,7 @@ func TestInstallTargetGetReleaseTag(t *testing.T) {
 
 	{
 		// Specified owner and repo is not found
-		it := &installTarget{githubAPIURL: ts.URL}
+		it := &installTarget{apiGithubURL: ts.URL}
 		releaseTag, err := it.getReleaseTag("owner1", "not-found-repo")
 		assert.Error(t, err, "Returns err if the repository is not found")
 		assert.Equal(t, "", releaseTag, "Returns empty string")
@@ -535,7 +535,7 @@ func TestInstallTargetGetReleaseTag(t *testing.T) {
 
 	{
 		// Get latest releaseTag correctly
-		it := &installTarget{githubAPIURL: ts.URL}
+		it := &installTarget{apiGithubURL: ts.URL}
 		releaseTag, err := it.getReleaseTag("owner1", "repo1")
 		assert.NoError(t, err, "getReleaseTag is successful")
 		assert.Equal(t, "v0.5.1", releaseTag, "releaseTag is fetched correctly from api")
@@ -550,10 +550,10 @@ func TestInstallTargetGetRawGithubURL(t *testing.T) {
 	assert.Equal(t, "https://example.com", it.getRawGithubURL(), "Returns customized URL")
 }
 
-func TestInstallTargetGetGithubAPIURL(t *testing.T) {
+func TestInstallTargetGetAPIGithubURL(t *testing.T) {
 	it := &installTarget{}
-	assert.Equal(t, "https://api.github.com/", it.getGithubAPIURL().String(), "Returns default URL")
+	assert.Equal(t, "https://api.github.com/", it.getAPIGithubURL().String(), "Returns default URL")
 
-	it = &installTarget{githubAPIURL: "https://api.example.com"}
-	assert.Equal(t, "https://api.example.com/", it.getGithubAPIURL().String(), "Returns customized URL")
+	it = &installTarget{apiGithubURL: "https://api.example.com"}
+	assert.Equal(t, "https://api.example.com/", it.getAPIGithubURL().String(), "Returns customized URL")
 }

--- a/plugin/github.go
+++ b/plugin/github.go
@@ -1,0 +1,17 @@
+package plugin
+
+import (
+	"os"
+
+	gitconfig "github.com/tcnksm/go-gitconfig"
+)
+
+// Get github token from environment variables, or github.token in gitconfig file
+func getGithubToken() string {
+	token := os.Getenv("GITHUB_TOKEN")
+	if token != "" {
+		return token
+	}
+	token, _ = gitconfig.GithubToken()
+	return token
+}

--- a/plugin/github.go
+++ b/plugin/github.go
@@ -1,10 +1,26 @@
 package plugin
 
 import (
+	"context"
+	"net/http"
 	"os"
 
+	"github.com/google/go-github/github"
 	gitconfig "github.com/tcnksm/go-gitconfig"
+	"golang.org/x/oauth2"
 )
+
+// Get github client having github token.
+func getGithubClient(ctx context.Context) *github.Client {
+	var oauthClient *http.Client
+	if token := getGithubToken(); token != "" {
+		ts := oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: getGithubToken()},
+		)
+		oauthClient = oauth2.NewClient(ctx, ts)
+	}
+	return github.NewClient(oauthClient)
+}
 
 // Get github token from environment variables, or github.token in gitconfig file
 func getGithubToken() string {

--- a/plugin/github_test.go
+++ b/plugin/github_test.go
@@ -1,0 +1,43 @@
+package plugin
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetGithubToken(t *testing.T) {
+	// Makes related environments empty,
+	// and reset these after test
+	origTokenEnv := os.Getenv("GITHUB_TOKEN")
+	defer os.Setenv("GITHUB_TOKEN", origTokenEnv)
+	os.Unsetenv("GITHUB_TOKEN")
+	origGitConfigEnv := os.Getenv("GIT_CONFIG")
+	defer os.Setenv("GIT_CONFIG", origGitConfigEnv)
+	os.Unsetenv("GIT_CONFIG")
+
+	{
+		// Get token from environment variable
+		os.Setenv("GITHUB_TOKEN", "tokenFromEnv")
+		token := getGithubToken()
+		assert.Equal(t, "tokenFromEnv", token)
+		os.Unsetenv("GITHUB_TOKEN")
+	}
+
+	{
+		// Get token from .gitconfig
+		os.Setenv("GIT_CONFIG", "testdata/gitconfig")
+		token := getGithubToken()
+		assert.Equal(t, "tokenFromGitConfig", token)
+		os.Unsetenv("GIT_CONFIG")
+	}
+
+	{
+		// Cannot get token from not existing file
+		os.Setenv("GIT_CONFIG", "testdata/not_exists")
+		token := getGithubToken()
+		assert.Equal(t, "", token)
+		os.Unsetenv("GIT_CONFIG")
+	}
+}

--- a/plugin/testdata/gitconfig
+++ b/plugin/testdata/gitconfig
@@ -1,0 +1,2 @@
+[github]
+	token = tokenFromGitConfig


### PR DESCRIPTION
This pull request implements 

- installing a mackerel plugin from latest Github Releases
- handling github token
    - get github token from `GITHUB_TOKEN` env or `github.token` in .gitconfig

For example, if we execute `mkr plugin install shibayu36/mackerel-plugin-sample`, then 

- mkr will looks for latest release (from https://github.com/shibayu36/mackerel-plugin-sample/releases )
- mkr will find `v0.0.5` release
- then mkr will install this release (like `mkr plugin install shibayu36/mackerel-plugin-sample@v0.0.5`)

## How to try this feature
Change commands.go like following, and execute in your terminal.

- `go run $(go list -f '{{join .GoFiles " "}}') plugin install --prefix ./mackerel-agent/plugins shibayu36/mackerel-plugin-sample`
- `go run $(go list -f '{{join .GoFiles " "}}') plugin install --prefix ./mackerel-agent/plugins mackerel-plugin-sample`
    - Install latest, also using the plugin registry

```diff
diff --git a/commands.go b/commands.go
index e2df850..d53212a 100644
--- a/commands.go
+++ b/commands.go
@@ -11,7 +11,7 @@ import (
        "github.com/Songmu/prompter"
        mkr "github.com/mackerelio/mackerel-client-go"
        "github.com/mackerelio/mkr/logger"
-       _ "github.com/mackerelio/mkr/plugin"
+       "github.com/mackerelio/mkr/plugin"
        "gopkg.in/urfave/cli.v1"
 )

@@ -47,7 +47,7 @@ var Commands = []cli.Command{
        commandAlerts,
        commandDashboards,
        commandAnnotations,
-       // plugin.CommandPlugin,
+       plugin.CommandPlugin,
 }
```
