### PR TITLE
Add overwrite flag to overwrite an existing plugin

### DIFF
--- a/plugin/commands.go
+++ b/plugin/commands.go
@@ -37,6 +37,10 @@ var CommandPlugin = cli.Command{
 					Name:  "prefix",
 					Usage: "plugin install location",
 				},
+				cli.BoolFlag{
+					Name: "force",
+					Usage: "Force overwriting an existing plugin",
+				},
 			},
 		},
 	},
@@ -76,7 +80,7 @@ func doPluginInstall(c *cli.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "Failed to install plugin while downloading an artifact")
 	}
-	err = installByArtifact(artifactFile, filepath.Join(pluginDir, "bin"), workdir)
+	err = installByArtifact(artifactFile, filepath.Join(pluginDir, "bin"), workdir, c.Bool("force"))
 	if err != nil {
 		return errors.Wrap(err, "Failed to install plugin while extracting and placing")
 	}
@@ -132,7 +136,7 @@ func downloadPluginArtifact(u, workdir string) (fpath string, err error) {
 }
 
 // Extract artifact and install plugin
-func installByArtifact(artifactFile, bindir, workdir string) error {
+func installByArtifact(artifactFile, bindir, workdir string, force bool) error {
 	// unzip artifact to work directory
 	err := archiver.Zip.Open(artifactFile, workdir)
 	if err != nil {
@@ -152,7 +156,7 @@ func installByArtifact(artifactFile, bindir, workdir string) error {
 		name := info.Name()
 		isExecutable := (info.Mode() & 0111) != 0
 		if isExecutable && looksLikePlugin(name) {
-			return placePlugin(path, filepath.Join(bindir, name))
+			return placePlugin(path, filepath.Join(bindir, name), force)
 		}
 
 		// `path` is a file but not plugin.
@@ -164,9 +168,9 @@ func looksLikePlugin(name string) bool {
 	return strings.HasPrefix(name, "check-") || strings.HasPrefix(name, "mackerel-plugin-")
 }
 
-func placePlugin(src, dest string) error {
+func placePlugin(src, dest string, force bool) error {
 	_, err := os.Stat(dest)
-	if err == nil {
+	if err == nil && !force {
 		logger.Log("", fmt.Sprintf("%s already exists. Skip installing for now", dest))
 		return nil
 	}

--- a/plugin/commands_test.go
+++ b/plugin/commands_test.go
@@ -136,7 +136,7 @@ func TestInstallByArtifact(t *testing.T) {
 			"Install is skipped, so the contents is what is before",
 		)
 
-		// Install same name plugin forcefully
+		// Install same name plugin with overwrite option
 		workdir3 := tempd(t)
 		defer os.RemoveAll(workdir3)
 		err = installByArtifact("testdata/mackerel-plugin-sample-duplicate_linux_amd64.zip", bindir, workdir3, true)
@@ -145,7 +145,7 @@ func TestInstallByArtifact(t *testing.T) {
 			t,
 			installedPath,
 			"testdata/mackerel-plugin-sample-duplicate_linux_amd64/mackerel-plugin-sample",
-			"a plugin is installed forcefully, so the contents is overwritten",
+			"a plugin is installed with overwrite option, so the contents is overwritten",
 		)
 	}
 

--- a/plugin/commands_test.go
+++ b/plugin/commands_test.go
@@ -106,7 +106,7 @@ func TestInstallByArtifact(t *testing.T) {
 		workdir := tempd(t)
 		defer os.RemoveAll(workdir)
 
-		err := installByArtifact("testdata/mackerel-plugin-sample_linux_amd64.zip", bindir, workdir)
+		err := installByArtifact("testdata/mackerel-plugin-sample_linux_amd64.zip", bindir, workdir, false)
 		assert.Nil(t, err, "installByArtifact finished successfully")
 
 		installedPath := filepath.Join(bindir, "mackerel-plugin-sample")
@@ -124,7 +124,7 @@ func TestInstallByArtifact(t *testing.T) {
 		// Install same name plugin, but it is skipped
 		workdir2 := tempd(t)
 		defer os.RemoveAll(workdir2)
-		err = installByArtifact("testdata/mackerel-plugin-sample-duplicate_linux_amd64.zip", bindir, workdir2)
+		err = installByArtifact("testdata/mackerel-plugin-sample-duplicate_linux_amd64.zip", bindir, workdir2, false)
 		assert.Nil(t, err, "installByArtifact finished successfully even if same name plugin exists")
 
 		fi, err = os.Stat(filepath.Join(bindir, "mackerel-plugin-sample"))
@@ -135,6 +135,18 @@ func TestInstallByArtifact(t *testing.T) {
 			"testdata/mackerel-plugin-sample_linux_amd64/mackerel-plugin-sample",
 			"Install is skipped, so the contents is what is before",
 		)
+
+		// Install same name plugin forcefully
+		workdir3 := tempd(t)
+		defer os.RemoveAll(workdir3)
+		err = installByArtifact("testdata/mackerel-plugin-sample-duplicate_linux_amd64.zip", bindir, workdir3, true)
+		assert.Nil(t, err, "installByArtifact finished successfully")
+		assertEqualFileContent(
+			t,
+			installedPath,
+			"testdata/mackerel-plugin-sample-duplicate_linux_amd64/mackerel-plugin-sample",
+			"a plugin is installed forcefully, so the contents is overwritten",
+		)
 	}
 
 	{
@@ -144,7 +156,7 @@ func TestInstallByArtifact(t *testing.T) {
 		workdir := tempd(t)
 		defer os.RemoveAll(workdir)
 
-		installByArtifact("testdata/mackerel-plugin-sample-multi_darwin_386.zip", bindir, workdir)
+		installByArtifact("testdata/mackerel-plugin-sample-multi_darwin_386.zip", bindir, workdir, false)
 
 		// check-sample, mackerel-plugin-sample-multi-1 and plugins/mackerel-plugin-sample-multi-2
 		// are installed.  But followings are not installed


### PR DESCRIPTION
This pull request add `--overwrite` flag for `mkr plugin install` to force overwriting an existing plugin.

## how to try this feature
At first, fix commands.go like https://github.com/mackerelio/mkr/pull/123 .  And then

- `go run $(go list -f '{{join .GoFiles " "}}') plugin install --prefix ./mackerel-agent/plugins --overwrite mackerel-plugin-sample`