### PR TITLE
[plugin.install] support direct URL target

### DIFF
--- a/plugin/client.go
+++ b/plugin/client.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"fmt"
 	"net/http"
+	"strings"
 )
 
 // client provides utilities for http request
@@ -12,20 +13,25 @@ const userAgent = "mkr-plugin-installer/0.0.0"
 
 // Get response from `url`
 func (c *client) get(url string) (*http.Response, error) {
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	resp, err := func() (*http.Response, error) {
+		if strings.HasPrefix(url, "file:///") {
+			t := &http.Transport{}
+			t.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
+			return (&http.Client{Transport: t}).Get(url)
+		}
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("User-Agent", userAgent)
+		return http.DefaultClient.Do(req)
+	}()
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("User-Agent", userAgent)
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
 	if resp.StatusCode != http.StatusOK {
-		err = fmt.Errorf("http response not OK. code: %d, url: %s", resp.StatusCode, url)
-		return nil, err
+		resp.Body.Close()
+		return nil, fmt.Errorf("http response not OK. code: %d, url: %s", resp.StatusCode, url)
 	}
-
 	return resp, nil
 }

--- a/plugin/install_target.go
+++ b/plugin/install_target.go
@@ -28,8 +28,11 @@ const (
 )
 
 // the pattern of installTarget string
-// (?:<plugin_name>|<owner>/<repo>)(?:@<releaseTag>)?
-var targetReg = regexp.MustCompile(`^(?:([^@/]+)/([^@/]+)|([^@/]+))(?:@(.+))?$`)
+var (
+	// (?:<plugin_name>|<owner>/<repo>)(?:@<releaseTag>)?
+	targetReg = regexp.MustCompile(`^(?:([^@/]+)/([^@/]+)|([^@/]+))(?:@(.+))?$`)
+	urlReg    = regexp.MustCompile(`^(?:https?|file)://`)
+)
 
 // Parse install target string, and construct installTarget
 // example is below
@@ -37,7 +40,7 @@ var targetReg = regexp.MustCompile(`^(?:([^@/]+)/([^@/]+)|([^@/]+))(?:@(.+))?$`)
 // - mackerel-plugin-sample
 // - mackerelio/mackerel-plugin-sample@v0.0.1
 func newInstallTargetFromString(target string) (*installTarget, error) {
-	if strings.HasPrefix(target, "http://") || strings.HasPrefix(target, "https://") {
+	if urlReg.MatchString(target) {
 		return &installTarget{
 			directURL: target,
 		}, nil

--- a/plugin/install_target.go
+++ b/plugin/install_target.go
@@ -15,6 +15,7 @@ type installTarget struct {
 	repo       string
 	pluginName string
 	releaseTag string
+	directURL  string
 
 	// fields for testing
 	rawGithubURL string
@@ -36,6 +37,12 @@ var targetReg = regexp.MustCompile(`^(?:([^@/]+)/([^@/]+)|([^@/]+))(?:@(.+))?$`)
 // - mackerel-plugin-sample
 // - mackerelio/mackerel-plugin-sample@v0.0.1
 func newInstallTargetFromString(target string) (*installTarget, error) {
+	if strings.HasPrefix(target, "http://") || strings.HasPrefix(target, "https://") {
+		return &installTarget{
+			directURL: target,
+		}, nil
+	}
+
 	matches := targetReg.FindStringSubmatch(target)
 	if len(matches) != 5 {
 		return nil, fmt.Errorf("Install target is invalid: %s", target)
@@ -52,6 +59,10 @@ func newInstallTargetFromString(target string) (*installTarget, error) {
 
 // Make artifact's download URL
 func (it *installTarget) makeDownloadURL() (string, error) {
+	if it.directURL != "" {
+		return it.directURL, nil
+	}
+
 	owner, repo, err := it.getOwnerAndRepo()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
By this patch, we can do the following things.

```sh
mkr plugin install https://www.example.com/mackerel-plugin-hoge.zip
```

supported URL schemes as follows.

- http
- https
- file