### PR TITLE
Fix copying plugin archives while installing a plugin on Windows

### DIFF
--- a/plugin/install.go
+++ b/plugin/install.go
@@ -197,7 +197,8 @@ func installByArtifact(artifactFile, bindir, workdir string, overwrite bool) err
 }
 
 func looksLikePlugin(name string) bool {
-	return strings.HasPrefix(name, "check-") || strings.HasPrefix(name, "mackerel-plugin-")
+	return (strings.HasPrefix(name, "check-") || strings.HasPrefix(name, "mackerel-plugin-")) &&
+		(!strings.HasSuffix(name, ".zip") && !strings.HasSuffix(name, ".tar.gz"))
 }
 
 func placePlugin(src, dest string, overwrite bool) error {

--- a/plugin/install.go
+++ b/plugin/install.go
@@ -197,8 +197,10 @@ func installByArtifact(artifactFile, bindir, workdir string, overwrite bool) err
 }
 
 func looksLikePlugin(name string) bool {
-	return (strings.HasPrefix(name, "check-") || strings.HasPrefix(name, "mackerel-plugin-")) &&
-		(!strings.HasSuffix(name, ".zip") && !strings.HasSuffix(name, ".tar.gz"))
+	if strings.HasSuffix(name, ".zip") || strings.HasSuffix(name, ".tar.gz") || strings.HasSuffix(name, ".tgz") {
+		return false
+	}
+	return strings.HasPrefix(name, "check-") || strings.HasPrefix(name, "mackerel-plugin-")
 }
 
 func placePlugin(src, dest string, overwrite bool) error {

--- a/plugin/install_test.go
+++ b/plugin/install_test.go
@@ -289,6 +289,8 @@ func TestLooksLikePlugin(t *testing.T) {
 		{"hoge-mackerel-plugin-sample", false},
 		{"hoge-check-sample", false},
 		{"wrong-sample", false},
+		{"mackerel-plugin-sample.zip", false},
+		{"check-sample.tar.gz", false},
 	}
 
 	for _, tc := range testCases {

--- a/plugin/install_test.go
+++ b/plugin/install_test.go
@@ -290,6 +290,7 @@ func TestLooksLikePlugin(t *testing.T) {
 		{"hoge-check-sample", false},
 		{"wrong-sample", false},
 		{"mackerel-plugin-sample.zip", false},
+		{"mackerel-plugin-sample.tgz", false},
 		{"check-sample.tar.gz", false},
 	}
 


### PR DESCRIPTION
In the current implementation, `mkr plugin install mackerel-plugin-sample` on Windows installs the plugin archive (~.zip) in the bin directory. We cannot distinguish the plugin executable and archive by file permission on Windows. 