### PR TITLE
[nit] Use Go 1.9.x on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.9
+- 1.9.x
 env:
   global:
   - PATH=~/bin:~/gopath/bin:$PATH


### PR DESCRIPTION
I think we want to use the latest patch version resolved by https://github.com/travis-ci/travis-build.