### PR TITLE
Support empty threshold for monitors

### DIFF
--- a/alerts.go
+++ b/alerts.go
@@ -134,51 +134,48 @@ func formatJoinedAlert(alertSet *alertSet, colorize bool) string {
 		case *mkr.MonitorConnectivity:
 			monitorMsg = ""
 		case *mkr.MonitorHostMetric:
-			switch alert.Status {
-			case "CRITICAL":
-				monitorMsg = fmt.Sprintf("%s %.2f %s %.2f", m.Metric, alert.Value, m.Operator, m.Critical)
-			case "WARNING":
-				monitorMsg = fmt.Sprintf("%s %.2f %s %.2f", m.Metric, alert.Value, m.Operator, m.Warning)
-			default:
-				monitorMsg = fmt.Sprintf("%s %.2f %s %.2f", m.Metric, alert.Value, m.Operator, m.Critical)
+			if alert.Status == "CRITICAL" && m.Critical != nil {
+				monitorMsg = fmt.Sprintf("%s %.2f %s %.2f", m.Metric, alert.Value, m.Operator, *m.Critical)
+			} else if alert.Status == "WARNING" && m.Warning != nil {
+				monitorMsg = fmt.Sprintf("%s %.2f %s %.2f", m.Metric, alert.Value, m.Operator, *m.Warning)
+			} else {
+				monitorMsg = fmt.Sprintf("%s %.2f", m.Metric, alert.Value)
 			}
 		case *mkr.MonitorServiceMetric:
-			switch alert.Status {
-			case "CRITICAL":
-				monitorMsg = fmt.Sprintf("%s %s %.2f %s %.2f", m.Service, m.Metric, alert.Value, m.Operator, m.Critical)
-			case "WARNING":
-				monitorMsg = fmt.Sprintf("%s %s %.2f %s %.2f", m.Service, m.Metric, alert.Value, m.Operator, m.Warning)
-			default:
-				monitorMsg = fmt.Sprintf("%s %s %.2f %s %.2f", m.Service, m.Metric, alert.Value, m.Operator, m.Critical)
+			if alert.Status == "CRITICAL" && m.Critical != nil {
+				monitorMsg = fmt.Sprintf("%s %s %.2f %s %.2f", m.Service, m.Metric, alert.Value, m.Operator, *m.Critical)
+			} else if alert.Status == "WARNING" && m.Warning != nil {
+				monitorMsg = fmt.Sprintf("%s %s %.2f %s %.2f", m.Service, m.Metric, alert.Value, m.Operator, *m.Warning)
+			} else {
+				monitorMsg = fmt.Sprintf("%s %s %.2f", m.Service, m.Metric, alert.Value)
 			}
 		case *mkr.MonitorExternalHTTP:
 			statusRegexp, _ := regexp.Compile("^[2345][0-9][0-9]$")
 			switch alert.Status {
 			case "CRITICAL":
-				if statusRegexp.MatchString(alert.Message) {
-					monitorMsg = fmt.Sprintf("%s %.2f > %.2f msec, status:%s", m.URL, alert.Value, m.ResponseTimeCritical, alert.Message)
+				if statusRegexp.MatchString(alert.Message) && m.ResponseTimeCritical != nil {
+					monitorMsg = fmt.Sprintf("%s %.2f > %.2f msec, status:%s", m.URL, alert.Value, *m.ResponseTimeCritical, alert.Message)
 				} else {
 					monitorMsg = fmt.Sprintf("%s %.2f msec, %s", m.URL, alert.Value, alert.Message)
 				}
 			case "WARNING":
-				if statusRegexp.MatchString(alert.Message) {
-					monitorMsg = fmt.Sprintf("%.2f > %.2f msec, status:%s", alert.Value, m.ResponseTimeWarning, alert.Message)
+				if statusRegexp.MatchString(alert.Message) && m.ResponseTimeWarning != nil {
+					monitorMsg = fmt.Sprintf("%.2f > %.2f msec, status:%s", alert.Value, *m.ResponseTimeWarning, alert.Message)
 				} else {
 					monitorMsg = fmt.Sprintf("%.2f msec, %s", alert.Value, alert.Message)
 				}
 			default:
-				monitorMsg = fmt.Sprintf("%.2f > %.2f msec, status:%s", alert.Value, m.ResponseTimeCritical, alert.Message)
+				monitorMsg = fmt.Sprintf("%.2f msec, status:%s", alert.Value, alert.Message)
 			}
 		case *mkr.MonitorExpression:
 			expression := formatExpressionOneline(m.Expression)
-			switch alert.Status {
-			case "CRITICAL":
-				monitorMsg = fmt.Sprintf("%s %.2f %s %.2f", expression, alert.Value, m.Operator, m.Critical)
-			case "WARNING":
-				monitorMsg = fmt.Sprintf("%s %.2f %s %.2f", expression, alert.Value, m.Operator, m.Warning)
-			case "UNKNOWN":
+			if alert.Status == "CRITICAL" && m.Critical != nil {
+				monitorMsg = fmt.Sprintf("%s %.2f %s %.2f", expression, alert.Value, m.Operator, *m.Critical)
+			} else if alert.Status == "WARNING" && m.Warning != nil {
+				monitorMsg = fmt.Sprintf("%s %.2f %s %.2f", expression, alert.Value, m.Operator, *m.Warning)
+			} else if alert.Status == "UNKNOWN" {
 				monitorMsg = fmt.Sprintf("%s", expression)
-			default:
+			} else {
 				monitorMsg = fmt.Sprintf("%s %.2f", expression, alert.Value)
 			}
 		default:

--- a/alerts_test.go
+++ b/alerts_test.go
@@ -33,7 +33,7 @@ func TestFormatJoinedAlert(t *testing.T) {
 			&alertSet{
 				&mkr.Alert{ID: "2tZhm", Type: "host", Status: "CRITICAL", HostID: "3XYyG", MonitorID: "5rXR3", Value: 15.7, OpenedAt: 200},
 				&mkr.Host{ID: "3XYyG", Name: "app.example.com", Roles: mkr.Roles{"foo": {"bar", "baz"}}, Status: "working"},
-				&mkr.MonitorHostMetric{ID: "5rXR3", Type: "host", Name: "All::loadavg5", Metric: "loadavg5", Warning: 8.0, Critical: 12.0, Operator: ">"},
+				&mkr.MonitorHostMetric{ID: "5rXR3", Type: "host", Name: "All::loadavg5", Metric: "loadavg5", Warning: pfloat64(8.0), Critical: pfloat64(12.0), Operator: ">"},
 			},
 			"2tZhm 1970-01-01 00:03:20 CRITICAL All::loadavg5 loadavg5 15.70 > 12.00 app.example.com working [foo:bar,baz]",
 		},
@@ -41,7 +41,7 @@ func TestFormatJoinedAlert(t *testing.T) {
 			&alertSet{
 				&mkr.Alert{ID: "2tZhm", Type: "service", Status: "WARNING", MonitorID: "5rXR3", Value: 15.7, OpenedAt: 300},
 				nil,
-				&mkr.MonitorServiceMetric{ID: "5rXR3", Type: "service", Service: "ServiceFoo", Name: "bar.baz monitor", Metric: "custom.bar.baz", Warning: 10.0, Critical: 20.0, Operator: ">"},
+				&mkr.MonitorServiceMetric{ID: "5rXR3", Type: "service", Service: "ServiceFoo", Name: "bar.baz monitor", Metric: "custom.bar.baz", Warning: pfloat64(10.0), Critical: pfloat64(20.0), Operator: ">"},
 			},
 			"2tZhm 1970-01-01 00:05:00 WARNING bar.baz monitor ServiceFoo custom.bar.baz 15.70 > 10.00",
 		},
@@ -49,7 +49,7 @@ func TestFormatJoinedAlert(t *testing.T) {
 			&alertSet{
 				&mkr.Alert{ID: "2tZhm", Type: "external", Status: "CRITICAL", MonitorID: "5rXR3", Value: 2500, Message: "200", OpenedAt: 400},
 				nil,
-				&mkr.MonitorExternalHTTP{ID: "5rXR3", Type: "external", Name: "Example Domain", URL: "https://example.com", ResponseTimeWarning: 500, ResponseTimeCritical: 1000, ResponseTimeDuration: 5},
+				&mkr.MonitorExternalHTTP{ID: "5rXR3", Type: "external", Name: "Example Domain", URL: "https://example.com", ResponseTimeWarning: pfloat64(500), ResponseTimeCritical: pfloat64(1000), ResponseTimeDuration: puint64(5)},
 			},
 			"2tZhm 1970-01-01 00:06:40 CRITICAL Example Domain https://example.com 2500.00 > 1000.00 msec, status:200",
 		},
@@ -57,7 +57,7 @@ func TestFormatJoinedAlert(t *testing.T) {
 			&alertSet{
 				&mkr.Alert{ID: "2tZhm", Type: "expression", Status: "WARNING", MonitorID: "5rXR3", Value: 15.7, OpenedAt: 500},
 				nil,
-				&mkr.MonitorExpression{ID: "5rXR3", Type: "expression", Name: "Max loadavg5 monitor", Expression: "max(  \n  roleSlots(  \n    'service:role',\n    'loadavg5'\n  )\n)\n", Warning: 10.0, Critical: 20.0, Operator: ">"},
+				&mkr.MonitorExpression{ID: "5rXR3", Type: "expression", Name: "Max loadavg5 monitor", Expression: "max(  \n  roleSlots(  \n    'service:role',\n    'loadavg5'\n  )\n)\n", Warning: pfloat64(10.0), Critical: pfloat64(20.0), Operator: ">"},
 			},
 			"2tZhm 1970-01-01 00:08:20 WARNING Max loadavg5 monitor max(roleSlots('service:role', 'loadavg5')) 15.70 > 10.00",
 		},

--- a/monitors_test.go
+++ b/monitors_test.go
@@ -32,6 +32,14 @@ func TestValidateRoles(t *testing.T) {
 
 }
 
+func pfloat64(x float64) *float64 {
+	return &x
+}
+
+func puint64(x uint64) *uint64 {
+	return &x
+}
+
 func TestDiffMonitors(t *testing.T) {
 	const want = ` {
    "headers": [
@@ -42,7 +50,7 @@ func TestDiffMonitors(t *testing.T) {
    "type": "external",
    "url": "http://example.com"
  },`
-	a := &mkr.MonitorExternalHTTP{ID: "12345", Name: "foo", Type: "external", URL: "http://example.com", Service: "bar", ResponseTimeCritical: 1000, Headers: []mkr.HeaderField{}}
+	a := &mkr.MonitorExternalHTTP{ID: "12345", Name: "foo", Type: "external", URL: "http://example.com", Service: "bar", ResponseTimeCritical: pfloat64(1000), Headers: []mkr.HeaderField{}}
 	b := &mkr.MonitorExternalHTTP{ID: "12345", Name: "foo", Type: "external", URL: "http://example.com", Service: "bar", Headers: []mkr.HeaderField{}}
 	if got := diffMonitor(a, b); got != want {
 		t.Errorf("diffMonitor: got\n%s\nwant \n%s", got, want)
@@ -60,7 +68,7 @@ func TestMonitorSaveRules(t *testing.T) {
 		Type:                 "external",
 		URL:                  "http://example.com",
 		Service:              "bar",
-		ResponseTimeCritical: 1000,
+		ResponseTimeCritical: pfloat64(1000),
 		Headers:              []mkr.HeaderField{},
 	}
 	monitorSaveRules([]mkr.Monitor{a}, tmpFile.Name())


### PR DESCRIPTION
Empty threshold is supported in https://github.com/mackerelio/mackerel-client-go/pull/55 and this is an empty pull request to reflect the changes into CHANGELOG.

Edit: After all I have to fix some code for mkr alerts and the tests.