### PR TITLE
Add --upgrade option to plugin install.

### DIFF
--- a/plugin/install.go
+++ b/plugin/install.go
@@ -111,24 +111,24 @@ func doPluginInstall(c *cli.Context) error {
 		return errors.Wrap(err, "Failed to install plugin while making a download URL")
 	}
 
-	canUpgrade := true
+	isMetaDataStoreEnabled := true
 	meta, err := newMetaDataStore(pluginDir, it)
 	if err != nil {
 		if err == errDisaleMetaDataStore {
-			canUpgrade = false
+			isMetaDataStoreEnabled = false
 		} else {
 			return errors.Wrap(err, "Failed to prepare meta data store")
 		}
 	}
 
 	overwrite := c.Bool("overwrite")
-	if canUpgrade && c.Bool("upgrade") {
+	if isMetaDataStoreEnabled && c.Bool("upgrade") {
 		releaseTag, err := meta.load("release_tag")
 		if err != nil {
 			return errors.Wrap(err, "Failed to load release_tag")
 		}
 		if releaseTag == it.releaseTag {
-			logger.Log("", fmt.Sprintf("release_tag %s already exists. Skip installing for now", it.releaseTag))
+			logger.Log("", fmt.Sprintf("release_tag %s is already installed. Skip installing for now", it.releaseTag))
 			return nil
 		}
 		overwrite = true // force overwrite in upgrade

--- a/plugin/install_target.go
+++ b/plugin/install_target.go
@@ -93,6 +93,11 @@ func (it *installTarget) getOwnerAndRepo() (string, string, error) {
 		return it.owner, it.repo, nil
 	}
 
+	// if directURL is specified, target doesn't have owner and repo
+	if it.directURL != "" {
+		return "", "", fmt.Errorf("owner and repo are not found because directURL is specified")
+	}
+
 	// Get owner and repo from plugin registry
 	defURL := fmt.Sprintf(
 		"%s/mackerelio/plugin-registry/master/plugins/%s.json",

--- a/plugin/install_test.go
+++ b/plugin/install_test.go
@@ -127,7 +127,7 @@ func TestInstallByArtifact(t *testing.T) {
 			workdir := tempd(t)
 			defer os.RemoveAll(workdir)
 			err := installByArtifact("testdata/mackerel-plugin-sample-duplicate_linux_amd64.zip", bindir, workdir, false)
-			assert.Nil(t, err, "installByArtifact finished successfully even if same name plugin exists")
+			assert.Equal(t, err, errSkipInstall, "installByArtifact finished successfully even if same name plugin exists")
 
 			_, err = os.Stat(installedPath)
 			assert.Nil(t, err, "A plugin file exists")

--- a/plugin/install_test.go
+++ b/plugin/install_test.go
@@ -53,6 +53,11 @@ func TestSetupPluginDir(t *testing.T) {
 		if assert.Nil(t, err) {
 			assert.True(t, fi.IsDir(), "plugin work directory is created")
 		}
+
+		fi, err = os.Stat(filepath.Join(tmpd, "meta"))
+		if assert.Nil(t, err) {
+			assert.True(t, fi.IsDir(), "plugin meta directory is created")
+		}
 	})
 
 	t.Run("Creating plugin dir is failed because of directory's permission", func(t *testing.T) {

--- a/plugin/meta_data_store.go
+++ b/plugin/meta_data_store.go
@@ -31,17 +31,13 @@ func newMetaDataStore(pluginDir string, target *installTarget) (*metaDataStore, 
 }
 
 func (m *metaDataStore) load(key string) (string, error) {
-	f, err := os.OpenFile(
-		filepath.Join(m.dir, key),
-		os.O_RDONLY|os.O_CREATE,
-		0644,
-	)
-	if err != nil {
+	b, err := ioutil.ReadFile(filepath.Join(m.dir, key))
+	if os.IsNotExist(err) {
+		return "", nil
+	} else if err != nil {
 		return "", err
 	}
-	defer f.Close()
-	b, err := ioutil.ReadAll(f)
-	return string(b), err
+	return string(b), nil
 }
 
 func (m *metaDataStore) store(key, value string) error {

--- a/plugin/meta_data_store.go
+++ b/plugin/meta_data_store.go
@@ -4,6 +4,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/pkg/errors"
 )
 
 type metaDataStore struct {
@@ -11,8 +13,14 @@ type metaDataStore struct {
 	installTarget *installTarget
 }
 
+var errDisaleMetaDataStore = errors.New("MetaData disabled. cloud not detect owner/repo")
+
 func newMetaDataStore(pluginDir string, it *installTarget) (*metaDataStore, error) {
-	dir := filepath.Join(pluginDir, "meta", it.owner, it.repo)
+	owner, repo, err := it.getOwnerAndRepo()
+	if err != nil {
+		return nil, errDisaleMetaDataStore
+	}
+	dir := filepath.Join(pluginDir, "meta", owner, repo)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return nil, err
 	}

--- a/plugin/meta_data_store.go
+++ b/plugin/meta_data_store.go
@@ -1,0 +1,45 @@
+package plugin
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+type metaDataStore struct {
+	dir           string
+	installTarget *installTarget
+}
+
+func newMetaDataStore(pluginDir string, it *installTarget) (*metaDataStore, error) {
+	dir := filepath.Join(pluginDir, "meta", it.owner, it.repo)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, err
+	}
+	return &metaDataStore{
+		dir:           dir,
+		installTarget: it,
+	}, nil
+}
+
+func (m *metaDataStore) load(key string) (string, error) {
+	f, err := os.OpenFile(
+		filepath.Join(m.dir, key),
+		os.O_RDONLY|os.O_CREATE,
+		0644,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	b, err := ioutil.ReadAll(f)
+	return string(b), err
+}
+
+func (m *metaDataStore) store(key, value string) error {
+	return ioutil.WriteFile(
+		filepath.Join(m.dir, key),
+		[]byte(value),
+		0644,
+	)
+}

--- a/plugin/meta_data_store.go
+++ b/plugin/meta_data_store.go
@@ -13,7 +13,7 @@ type metaDataStore struct {
 	installTarget *installTarget
 }
 
-var errDisaleMetaDataStore = errors.New("MetaData disabled. cloud not detect owner/repo")
+var errDisaleMetaDataStore = errors.New("MetaData disabled. could not detect owner/repo")
 
 func newMetaDataStore(pluginDir string, it *installTarget) (*metaDataStore, error) {
 	owner, repo, err := it.getOwnerAndRepo()

--- a/plugin/meta_data_store.go
+++ b/plugin/meta_data_store.go
@@ -15,8 +15,8 @@ type metaDataStore struct {
 
 var errDisaleMetaDataStore = errors.New("MetaData disabled. could not detect owner/repo")
 
-func newMetaDataStore(pluginDir string, it *installTarget) (*metaDataStore, error) {
-	owner, repo, err := it.getOwnerAndRepo()
+func newMetaDataStore(pluginDir string, target *installTarget) (*metaDataStore, error) {
+	owner, repo, err := target.getOwnerAndRepo()
 	if err != nil {
 		return nil, errDisaleMetaDataStore
 	}
@@ -26,7 +26,7 @@ func newMetaDataStore(pluginDir string, it *installTarget) (*metaDataStore, erro
 	}
 	return &metaDataStore{
 		dir:           dir,
-		installTarget: it,
+		installTarget: target,
 	}, nil
 }
 

--- a/plugin/meta_data_store_test.go
+++ b/plugin/meta_data_store_test.go
@@ -1,0 +1,40 @@
+package plugin
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewMetaData(t *testing.T) {
+	tmpd := tempd(t)
+	defer os.RemoveAll(tmpd)
+
+	it, err := newInstallTargetFromString("mackerelio/mackerel-plugin-sample@v1.0.1")
+	assert.Nil(t, err, "error does not occur while newInstallTargetFromString")
+
+	meta, err := newMetaDataStore(tmpd, it)
+	assert.Nil(t, err, "error does not occur while newMetaDataStore")
+
+	v1, err := meta.load("foo")
+	assert.Nil(t, err, "error does not occur while meta.load")
+	assert.Equal(t, v1, "", "load uninitialized value must be empty string")
+
+	err = meta.store("foo", "bar")
+	assert.Nil(t, err, "error does not occur while meta.store")
+
+	v2, err := meta.load("foo")
+	assert.Nil(t, err, "error does not occur while meta.load")
+	assert.Equal(t, v2, "bar", "load successful")
+
+	err = meta.store("foo", "baz")
+	assert.Nil(t, err, "error does not occur while meta.store")
+
+	v3, err := meta.load("foo")
+	assert.Nil(t, err, "error does not occur while meta.load")
+	assert.Equal(t, v3, "baz", "load successful")
+
+	_, err = meta.load("")
+	assert.Error(t, err, "error occured while meta.load with empty key")
+}


### PR DESCRIPTION
I added `--upgrade` option to `plugin install`.

`--overwrite` option always download archives from remote, and overwrite files.
But I want to reduce installation time and bandwidth if it is not necessary.

This PR add a meta data store for plugins.
Meta data(release_tag) stored at installed will be compared at next time.

Works as below.

metadata is created after Install a plugin.
```console
$ mkr plugin install mackerelio/mackerel-plugin-sample
           Downloading https://github.com/mackerelio/mackerel-plugin-sample/releases/download/v0.0.3/mackerel-plugin-sample_darwin_amd64.zip
           Installing /opt/mackerel-agent/plugins/bin/mackerel-plugin-sample
           Successfully installed mackerelio/mackerel-plugin-sample
$ cat /opt/mackerel-agent/plugins/meta/mackerelio/mackerel-plugin-sample/release_tag
v0.0.3
```

When use `--upgrade`, compeare release_tag with metadata before do install.
```console                                                                                                
$ mkr plugin install mackerelio/mackerel-plugin-sample --upgrade
           release_tag v0.0.3 already exists. Skip installing for now
```

`--upgrade` also allows downgrade (install smaller version).
```console
$ mkr plugin install mackerelio/mackerel-plugin-sample@v0.0.2 --upgrade
           Downloading https://github.com/mackerelio/mackerel-plugin-sample/releases/download/v0.0.2/mackerel-plugin-sample_darwin_amd64.zip
           Installing /opt/mackerel-agent/plugins/bin/mackerel-plugin-sample
           Successfully installed mackerelio/mackerel-plugin-sample@v0.0.2
$ cat /opt/mackerel-agent/plugins/meta/mackerelio/mackerel-plugin-sample/release_tag
v0.0.2
```

```console                                                                                                                              
$ mkr plugin install mackerelio/mackerel-plugin-sample --upgrade
           Downloading https://github.com/mackerelio/mackerel-plugin-sample/releases/download/v0.0.3/mackerel-plugin-sample_darwin_amd64.zip
           Installing /opt/mackerel-agent/plugins/bin/mackerel-plugin-sample
           Successfully installed mackerelio/mackerel-plugin-sample
$ cat /opt/mackerel-agent/plugins/meta/mackerelio/mackerel-plugin-sample/release_tag
v0.0.3
```