### PR TITLE
Add <direct_url> help

### DIFF
--- a/plugin/install.go
+++ b/plugin/install.go
@@ -56,6 +56,10 @@ var commandPluginInstall = cli.Command{
           Install from plugin registry.
           You can find available plugins in https://github.com/mackerelio/plugin-registry
           Example: mkr plugin install mackerel-plugin-sample
+    - <direct_url>
+          Install from specified URL.
+          Supported URL schemes are http, https and file.
+          Example: mkr plugin install https://github.com/mackerelio/mackerel-plugin-sample/releases/download/v0.0.3/mackerel-plugin-sample_linux_amd64.zip
 
     The installer uses Github API to find the latest release.  Please set a github token to
     GITHUB_TOKEN environment variable, or to github.token in .gitconfig.

--- a/plugin/install_target.go
+++ b/plugin/install_target.go
@@ -39,6 +39,8 @@ var (
 // - mackerelio/mackerel-plugin-sample
 // - mackerel-plugin-sample
 // - mackerelio/mackerel-plugin-sample@v0.0.1
+// - https://mackerel.io/mackerel-plugin-sample_linux_amd64.zip
+// - file:///path/to/mackerel-plugin-sample_linux_amd64.zip
 func newInstallTargetFromString(target string) (*installTarget, error) {
 	if urlReg.MatchString(target) {
 		return &installTarget{


### PR DESCRIPTION
Installing by direct URL is supported by https://github.com/mackerelio/mkr/pull/130.  But it wasn't documented.

This PR adds <direct_url> help.