### PR TITLE
Build with Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.9.x
+- 1.10.x
 env:
   global:
   - PATH=~/bin:~/gopath/bin:$PATH

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,10 @@ version: "{build}"
 clone_folder: c:\gopath\src\github.com\mackerelio\mkr
 environment:
   GOPATH: c:\gopath
+  GOROOT: c:\go110-x86
 build: off
 install:
-  - set PATH=C:\go\bin;%GOPATH%\bin;C:\msys64\mingw64\bin;%PATH%
+  - set PATH=%GOROOT%\bin;%GOPATH%\bin;C:\msys64\mingw64\bin;%PATH%
 test_script:
   - go get -d -v -t ./...
   - go test -v ./...


### PR DESCRIPTION
- Linux: 1.9 (Currently build failing) => 1.10
- Windows: latest(implicitly 1.10) => explicit 1.10