### PR TITLE
add Retry feature and --max-retry option to `mkr throw`

### DIFF
--- a/throw.go
+++ b/throw.go
@@ -17,18 +17,18 @@ import (
 var commandThrow = cli.Command{
 	Name:      "throw",
 	Usage:     "Post metric values",
-	ArgsUsage: "[--host | -H <hostId>] [--service | -s <service>] [--max-retry | -m N ] stdin",
+	ArgsUsage: "[--host | -H <hostId>] [--service | -s <service>] [--retry | -r N ] stdin",
 	Description: `
     Post metric values to 'host metric' or 'service metric'.
     Output format of metric values are compatible with that of a Sensu plugin.
     Requests "POST /api/v0/tsdb". See https://mackerel.io/api-docs/entry/host-metrics#post .
-    Automatically retries the API request when --max-retry is specified.
+    Automatically retries the API request when --retry is specified.
 `,
 	Action: doThrow,
 	Flags: []cli.Flag{
 		cli.StringFlag{Name: "host, H", Value: "", Usage: "Post host metric values to <hostID>."},
 		cli.StringFlag{Name: "service, s", Value: "", Usage: "Post service metric values to <service>."},
-		cli.IntFlag{Name: "max-retry, m", Usage: "Retries up to N times when API request fails."},
+		cli.IntFlag{Name: "retry, r", Usage: "Retries up to N times when API request fails."},
 	},
 }
 

--- a/throw.go
+++ b/throw.go
@@ -100,10 +100,12 @@ func doThrow(c *cli.Context) error {
 	return nil
 }
 
+var minInterval = 15 * time.Second
+
 func requestWithRetry(f func() error, maxRetry int) error {
 	b := &backoff.Backoff{
-		Min:    1 * time.Second,
-		Max:    1 * time.Minute,
+		Min:    minInterval,
+		Max:    5 * time.Minute,
 		Factor: 2,
 		Jitter: false,
 	}

--- a/throw.go
+++ b/throw.go
@@ -110,7 +110,7 @@ func requestWithRetry(f func() error) error {
 	var delay time.Duration
 	for int(b.Attempt()) < maxRetry {
 		if b.Attempt() > 0 {
-			logger.Log("warning", fmt.Sprintf("Failed to request. will retry after %.0f seconds...", delay.Seconds()))
+			logger.Log("warning", fmt.Sprintf("Failed to request. will retry after %.0f seconds. Error: %s", delay.Seconds(), err))
 			time.Sleep(delay)
 		}
 		if err = f(); err == nil {

--- a/throw.go
+++ b/throw.go
@@ -116,7 +116,13 @@ func requestWithRetry(f func() error) error {
 		if err = f(); err == nil {
 			// SUCCESS!!
 			break
+		} else if e, isAPIError := err.(*mkr.APIError); isAPIError {
+			// Do not retry when status is 4XX
+			if e.StatusCode >= 400 && e.StatusCode < 500 {
+				break
+			}
 		}
+
 		delay = b.Duration()
 	}
 	return err

--- a/throw.go
+++ b/throw.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jpillora/backoff"
+	mkr "github.com/mackerelio/mackerel-client-go"
+	"github.com/mackerelio/mkr/logger"
+	"gopkg.in/urfave/cli.v1"
+)
+
+var commandThrow = cli.Command{
+	Name:      "throw",
+	Usage:     "Post metric values",
+	ArgsUsage: "[--host | -H <hostId>] [--service | -s <service>] stdin",
+	Description: `
+    Post metric values to 'host metric' or 'service metric'.
+    Output format of metric values are compatible with that of a Sensu plugin.
+    Requests "POST /api/v0/tsdb". See https://mackerel.io/api-docs/entry/host-metrics#post .
+`,
+	Action: doThrow,
+	Flags: []cli.Flag{
+		cli.StringFlag{Name: "host, H", Value: "", Usage: "Post host metric values to <hostID>."},
+		cli.StringFlag{Name: "service, s", Value: "", Usage: "Post service metric values to <service>."},
+	},
+}
+
+func doThrow(c *cli.Context) error {
+	optHostID := c.String("host")
+	optService := c.String("service")
+
+	var metricValues []*(mkr.MetricValue)
+
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// name, value, timestamp
+		// ex.) tcp.CLOSING 0 1397031808
+		items := strings.Fields(line)
+		if len(items) != 3 {
+			continue
+		}
+		value, err := strconv.ParseFloat(items[1], 64)
+		if err != nil {
+			logger.Log("warning", fmt.Sprintf("Failed to parse values: %s", err))
+			continue
+		}
+		time, err := strconv.ParseInt(items[2], 10, 64)
+		if err != nil {
+			logger.Log("warning", fmt.Sprintf("Failed to parse values: %s", err))
+			continue
+		}
+
+		name := items[0]
+		if optHostID != "" && !strings.HasPrefix(name, "custom.") {
+			name = "custom." + name
+		}
+
+		metricValue := &mkr.MetricValue{
+			Name:  name,
+			Value: value,
+			Time:  time,
+		}
+
+		metricValues = append(metricValues, metricValue)
+	}
+	logger.ErrorIf(scanner.Err())
+
+	client := newMackerelFromContext(c)
+
+	if optHostID != "" {
+		logger.DieIf(requestWithRetry(func() error {
+			return client.PostHostMetricValuesByHostID(optHostID, metricValues)
+		}))
+
+		for _, metric := range metricValues {
+			logger.Log("thrown", fmt.Sprintf("%s '%s\t%f\t%d'", optHostID, metric.Name, metric.Value, metric.Time))
+		}
+	} else if optService != "" {
+		logger.DieIf(requestWithRetry(func() error {
+			return client.PostServiceMetricValues(optService, metricValues)
+		}))
+
+		for _, metric := range metricValues {
+			logger.Log("thrown", fmt.Sprintf("%s '%s\t%f\t%d'", optService, metric.Name, metric.Value, metric.Time))
+		}
+	} else {
+		cli.ShowCommandHelp(c, "throw")
+		os.Exit(1)
+	}
+	return nil
+}
+
+const maxRetry = 10
+
+func requestWithRetry(f func() error) error {
+	b := &backoff.Backoff{
+		Min:    1 * time.Second,
+		Max:    1 * time.Minute,
+		Factor: 2,
+		Jitter: false,
+	}
+	var err error
+	var delay time.Duration
+	for int(b.Attempt()) < maxRetry {
+		if b.Attempt() > 0 {
+			logger.Log("warning", fmt.Sprintf("Failed to request. will retry after %.0f seconds...", delay.Seconds()))
+			time.Sleep(delay)
+		}
+		if err = f(); err == nil {
+			// SUCCESS!!
+			break
+		}
+		delay = b.Duration()
+	}
+	return err
+}

--- a/throw_test.go
+++ b/throw_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	mkr "github.com/mackerelio/mackerel-client-go"
+)
+
+func TestRequestWithRetry_Success(t *testing.T) {
+	var counter int
+	var err error
+	f0 := func() error {
+		counter += 1
+		return nil
+	}
+
+	counter = 0
+	err = requestWithRetry(f0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if counter != 1 {
+		t.Errorf("function should be called only once, but called %d times", counter)
+	}
+
+	counter = 0
+	err = requestWithRetry(f0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if counter != 1 {
+		t.Errorf("function should be called only once, but called %d times", counter)
+	}
+
+	counter = 0
+	err = requestWithRetry(f0, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if counter != 1 {
+		t.Errorf("function should be called only once, but called %d times", counter)
+	}
+}
+
+func TestRequestWithRetry_Giveup(t *testing.T) {
+	var counter int
+	var err error
+	f0 := func() error {
+		counter += 1
+		return fmt.Errorf("ohno")
+	}
+
+	counter = 0
+	err = requestWithRetry(f0, 1)
+	if err == nil {
+		t.Error("error should occur")
+	}
+	if counter != 2 { // 1 + 1 retry
+		t.Errorf("function should be called 2 times, but called %d times", counter)
+	}
+
+	counter = 0
+	err = requestWithRetry(f0, 0)
+	if err == nil {
+		t.Error("error should occur")
+	}
+	if counter != 1 { // 1 + 0 retry
+		t.Errorf("function should be called only once, but called %d times", counter)
+	}
+
+	counter = 0
+	err = requestWithRetry(f0, 5)
+	if err == nil {
+		t.Error("error should occur")
+	}
+	if counter != 6 { // 1 + 5 retry
+		t.Errorf("function should be called 6 times, but called %d times", counter)
+	}
+}
+
+func TestRequestWithRetry_Recovery(t *testing.T) {
+	var counter int
+	var err error
+	f0 := func() error {
+		counter += 1
+		if counter < 3 {
+			return fmt.Errorf("Not yet")
+		}
+		return nil
+	}
+
+	counter = 0
+	err = requestWithRetry(f0, 1)
+	if err == nil {
+		t.Error("error should occur")
+	}
+	if counter != 2 { // 1 + 1 retry
+		t.Errorf("function should be called 2 times, but called %d times", counter)
+	}
+
+	counter = 0
+	err = requestWithRetry(f0, 5)
+	if err != nil {
+		t.Error("error should occur")
+	}
+	if counter != 3 { // Success on 3rd try
+		t.Errorf("function should be called 3 times, but called %d times", counter)
+	}
+}
+
+func TestRequestWithRetry_Status(t *testing.T) {
+	var counter int
+	var err error
+	var status int
+	f0 := func() error {
+		counter += 1
+		return &mkr.APIError{status, "ohno"}
+	}
+
+	counter = 0
+	status = 500
+	err = requestWithRetry(f0, 1)
+	if err == nil {
+		t.Error("error should occur")
+	}
+	if counter != 2 { // 1 + 1 retry
+		t.Errorf("function should be called 2 times, but called %d times", counter)
+	}
+
+	counter = 0
+	status = 403
+	err = requestWithRetry(f0, 1)
+	if err == nil {
+		t.Error("error should occur")
+	}
+	if counter != 1 { // 1 + 0 retry
+		t.Errorf("function should be called only once, but called %d times", counter)
+	}
+}

--- a/throw_test.go
+++ b/throw_test.go
@@ -3,9 +3,15 @@ package main
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	mkr "github.com/mackerelio/mackerel-client-go"
 )
+
+func init() {
+	// Shorten interval in tests
+	minInterval = 1 * time.Second
+}
 
 func TestRequestWithRetry_Success(t *testing.T) {
 	var counter int

--- a/throw_test.go
+++ b/throw_test.go
@@ -17,7 +17,7 @@ func TestRequestWithRetry_Success(t *testing.T) {
 	var counter int
 	var err error
 	f0 := func() error {
-		counter += 1
+		counter++
 		return nil
 	}
 
@@ -53,7 +53,7 @@ func TestRequestWithRetry_Giveup(t *testing.T) {
 	var counter int
 	var err error
 	f0 := func() error {
-		counter += 1
+		counter++
 		return fmt.Errorf("ohno")
 	}
 
@@ -89,7 +89,7 @@ func TestRequestWithRetry_Recovery(t *testing.T) {
 	var counter int
 	var err error
 	f0 := func() error {
-		counter += 1
+		counter++
 		if counter < 3 {
 			return fmt.Errorf("Not yet")
 		}
@@ -120,8 +120,8 @@ func TestRequestWithRetry_Status(t *testing.T) {
 	var err error
 	var status int
 	f0 := func() error {
-		counter += 1
-		return &mkr.APIError{status, "ohno"}
+		counter++
+		return &mkr.APIError{StatusCode: status, Message: "ohno"}
 	}
 
 	counter = 0


### PR DESCRIPTION
- Retry with exponential backoff (min interval is 15 sec and Max is 5 min).
- Don't retry when HTTP response is 4xx

demo:
```
[github.com/mackerelio/mkr]$ echo "tcp.CLOSING 0 1397031808" | ./mkr --apibase http://localhost:5000/ --conf /usr/local/etc/mackerel-agent.conf throw --host shiba
     error API request failed: 404 Not Found
[github.com/mackerelio/mkr]$ echo "tcp.CLOSING 0 1397031808" | ./mkr --apibase http://localhost:5000/ --conf /usr/local/etc/mackerel-agent.conf throw --host shiba
     error API request failed: 500 Internal Server Error
[github.com/mackerelio/mkr]$ echo "tcp.CLOSING 0 1397031808" | ./mkr --apibase http://localhost:5000/ --conf /usr/local/etc/mackerel-agent.conf throw --host shiba --max-retry 2
   warning Failed to request. will retry after 15 seconds. Error: API request failed: 500 Internal Server Error
   warning Failed to request. will retry after 30 seconds. Error: API request failed: 500 Internal Server Error
     error API request failed: 500 Internal Server Error
[github.com/mackerelio/mkr]$ echo "tcp.CLOSING 0 1397031808" | ./mkr --apibase http://localhost:5000/ --conf /usr/local/etc/mackerel-agent.conf throw --host shiba --max-retry 1
     error API request failed: 403 Forbidden
[github.com/mackerelio/mkr]$
```