### PR TITLE
Omit symbol table and debug information from the executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine3.7
+FROM golang:alpine3.7 AS builder
 RUN apk add --no-cache make git
 WORKDIR /go/src/github.com/mackerelio/mkr/
 COPY . .
@@ -6,5 +6,5 @@ RUN make build
 
 FROM alpine:3.7
 RUN apk add --no-cache ca-certificates
-COPY --from=0 /go/src/github.com/mackerelio/mkr/mkr /usr/local/bin/
+COPY --from=builder /go/src/github.com/mackerelio/mkr/mkr /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/mkr"]

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test: test-deps
 	go test -v ./...
 
 build: deps
-	go build -ldflags "-X main.gitcommit=$(CURRENT_REVISION)" -o $(BIN) .
+	go build -ldflags "-w -s -X main.gitcommit=$(CURRENT_REVISION)" -o $(BIN) .
 
 lint: test-deps
 	go vet ./...


### PR DESCRIPTION
Alternative of #164. This reduces the docker image size to 14.3MB (before: 19.9MB).