### PR TITLE
logs to Stderr

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -22,6 +22,10 @@ var logger = &colorine.Logger{
 	},
 }
 
+func init() {
+	logger.SetOutput(os.Stderr)
+}
+
 // Log outputs `message` with `prefix` by go-colorine
 func Log(prefix, message string) {
 	logger.Log(prefix, message)


### PR DESCRIPTION
The progress logs should be output to Stderr.
Although it is an incompatible change, it seems not to be a big problem.