### PR TITLE
[nit] Fix "go get" path for golint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ deps:
 
 test-deps:
 	go get -d -v -t ./...
-	go get github.com/golang/lint/golint
+	go get golang.org/x/lint/golint
 
 devel-deps: test-deps
 	go get github.com/mattn/goveralls


### PR DESCRIPTION
resolve the following error.

> can't load package: package github.com/golang/lint/golint: code in directory
> /path/to/gopath/src/github.com/golang/lint/golint expects import "golang.org/x/lint/golint"