### PR TITLE
implement org subcommand

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -47,6 +47,7 @@ var Commands = []cli.Command{
 	commandAlerts,
 	commandDashboards,
 	commandAnnotations,
+	commandOrg,
 	plugin.CommandPlugin,
 }
 

--- a/org.go
+++ b/org.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"github.com/mackerelio/mkr/logger"
+	"gopkg.in/urfave/cli.v1"
+)
+
+var commandOrg = cli.Command{
+	Name:  "org",
+	Usage: "Fetch organization",
+	Description: `
+    Fetch organization.
+    Requests APIs under "/api/v0/org". See https://mackerel.io/api-docs/entry/organizations .
+`,
+	Action: doOrgRetrieve,
+}
+
+func doOrgRetrieve(c *cli.Context) error {
+	client := newMackerelFromContext(c)
+
+	org, err := client.GetOrg()
+	logger.DieIf(err)
+	PrettyPrintJSON(org)
+	return nil
+}


### PR DESCRIPTION
This pull request implements a new subcommand: mkr org. This is useful to see which org the agent post the metric to, for users manage multiple organizations.