### PR TITLE
show alert.Message as monitor message in mkr alerts list

### DIFF
--- a/alerts.go
+++ b/alerts.go
@@ -214,12 +214,10 @@ func formatExpressionOneline(expr string) string {
 	return strings.Replace(strings.Replace(expr, "( ", "(", -1), " )", ")", -1)
 }
 
-var checkNewLinePattern = regexp.MustCompile(`[\r\n]+.*`)
-
 func formatCheckMessage(msg string) string {
 	truncated := false
-	if trimmed := checkNewLinePattern.ReplaceAllString(msg, ""); trimmed != msg {
-		msg = trimmed
+	if index := strings.IndexAny(msg, "\n\r"); index != -1 {
+		msg = msg[0:index]
 		truncated = true
 	}
 	if msgU := utf8string.NewString(msg); msgU.RuneCount() > 100 {

--- a/alerts.go
+++ b/alerts.go
@@ -187,6 +187,11 @@ func formatJoinedAlert(alertSet *alertSet, colorize bool) string {
 			monitorMsg = monitor.MonitorName() + " " + monitorMsg
 		}
 	}
+	// If alert is caused by check monitoring, take monitorMsg from alert.message
+	if alert.Type == "check" {
+		monitorMsg = alert.Message
+	}
+
 	statusMsg := alert.Status
 	if colorize {
 		switch alert.Status {

--- a/alerts.go
+++ b/alerts.go
@@ -10,7 +10,6 @@ import (
 	"github.com/fatih/color"
 	mkr "github.com/mackerelio/mackerel-client-go"
 	"github.com/mackerelio/mkr/logger"
-	"golang.org/x/exp/utf8string"
 	"gopkg.in/urfave/cli.v1"
 )
 
@@ -220,8 +219,8 @@ func formatCheckMessage(msg string) string {
 		msg = msg[0:index]
 		truncated = true
 	}
-	if msgU := utf8string.NewString(msg); msgU.RuneCount() > 100 {
-		msg = msgU.Slice(0, 100)
+	if runes := []rune(msg); len(runes) > 100 {
+		msg = string(runes[0:100])
 		truncated = true
 	}
 	if truncated {

--- a/alerts_test.go
+++ b/alerts_test.go
@@ -61,6 +61,30 @@ func TestFormatJoinedAlert(t *testing.T) {
 			},
 			"2tZhm 1970-01-01 00:08:20 WARNING Max loadavg5 monitor max(roleSlots('service:role', 'loadavg5')) 15.70 > 10.00",
 		},
+		{
+			&alertSet{
+				&mkr.Alert{ID: "2tZhm", Type: "check", Status: "WARNING", MonitorID: "5rXR3", OpenedAt: 500, Message: "Short check monitoring description"},
+				&mkr.Host{ID: "3XYyG", Name: "app.example.com", Roles: mkr.Roles{"foo": {"bar", "baz"}}, Status: "working"},
+				nil,
+			},
+			"2tZhm 1970-01-01 00:08:20 WARNING Short check monitoring description app.example.com working [foo:bar,baz]",
+		},
+		{
+			&alertSet{
+				&mkr.Alert{ID: "2tZhm", Type: "check", Status: "WARNING", MonitorID: "5rXR3", OpenedAt: 500, Message: "description with\nnew line\nmore new line "},
+				&mkr.Host{ID: "3XYyG", Name: "app.example.com", Roles: mkr.Roles{"foo": {"bar", "baz"}}, Status: "working"},
+				nil,
+			},
+			"2tZhm 1970-01-01 00:08:20 WARNING description with... app.example.com working [foo:bar,baz]",
+		},
+		{
+			&alertSet{
+				&mkr.Alert{ID: "2tZhm", Type: "check", Status: "WARNING", MonitorID: "5rXR3", OpenedAt: 500, Message: "long long long long long long long long long long long long long long long long long long long そして長い長い alert"},
+				&mkr.Host{ID: "3XYyG", Name: "app.example.com", Roles: mkr.Roles{"foo": {"bar", "baz"}}, Status: "working"},
+				nil,
+			},
+			"2tZhm 1970-01-01 00:08:20 WARNING long long long long long long long long long long long long long long long long long long long そして長い... app.example.com working [foo:bar,baz]",
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
example:
```
aaa 2018-10-26 17:05:52 CRITICAL HTTP CRITICAL: Get https://127.0.0.1/: dial tcp 127.0.0.1:443: connect: connection refused xxxproxy22.local standby [XXX:proxy]
bbb 2018-10-25 16:35:04 CRITICAL connectivity yyybackend10.local working [YYY:backend]
```

Handling:
- display up to 100 runes
- trim at first newline (`[\r\n]`)