### PR TITLE
update subcommand should keep the interface infromation

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -364,7 +364,6 @@ func doUpdate(c *cli.Context) error {
 		if needUpdateHost {
 			host, err := client.FindHost(hostID)
 			logger.DieIf(err)
-			meta := host.Meta
 			name := ""
 			if optName == "" {
 				name = host.Name
@@ -380,7 +379,8 @@ func doUpdate(c *cli.Context) error {
 			param := &mkr.UpdateHostParam{
 				Name:        name,
 				DisplayName: displayname,
-				Meta:        meta,
+				Meta:        host.Meta,
+				Interfaces:  host.Interfaces,
 			}
 			if needUpdateRolesInHostUpdate {
 				param.RoleFullnames = optRoleFullnames


### PR DESCRIPTION
Updating the display name by `mkr update --displayName foobar` removes the interfaces information unexpectedly. This pull request fixes the params to keep the interfaces information. Other fields are not necessarily filled because they are not deleted when empty.