### PR TITLE
add wrap subcommand to monitor batch jobs to run with cron etc

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mackerelio/mkr/checks"
 	"github.com/mackerelio/mkr/logger"
 	"github.com/mackerelio/mkr/plugin"
+	"github.com/mackerelio/mkr/wrap"
 	cli "gopkg.in/urfave/cli.v1"
 )
 
@@ -33,6 +34,7 @@ var Commands = []cli.Command{
 	commandOrg,
 	plugin.CommandPlugin,
 	checks.Command,
+	wrap.Command,
 }
 
 var commandStatus = cli.Command{

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -16,6 +16,7 @@ var logger = &colorine.Logger{
 		"error": colorine.Error,
 
 		"":        colorine.Info,
+		"info":    colorine.Info,
 		"created": colorine.Info,
 		"updated": colorine.Info,
 		"thrown":  colorine.Info,

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -3,6 +3,7 @@ package logger
 // We borrow this code from github.com/motemen/ghq/utils
 
 import (
+	"fmt"
 	"os"
 
 	colorine "github.com/motemen/go-colorine"
@@ -29,6 +30,12 @@ func init() {
 // Log outputs `message` with `prefix` by go-colorine
 func Log(prefix, message string) {
 	logger.Log(prefix, message)
+}
+
+// Logf outputs `message` with `prefix` by go-colorine
+func Logf(prefix, message string, args ...interface{}) {
+	msg := fmt.Sprintf(message, args...)
+	logger.Log(prefix, msg)
 }
 
 // ErrorIf outputs log if `err` occurs.

--- a/mkr.go
+++ b/mkr.go
@@ -31,7 +31,11 @@ func main() {
 
 	err := app.Run(os.Args)
 	if err != nil {
+		exitCode := 1
+		if excoder, ok := err.(cli.ExitCoder); ok {
+			exitCode = excoder.ExitCode()
+		}
 		logger.Log("error", err.Error())
-		os.Exit(1)
+		os.Exit(exitCode)
 	}
 }

--- a/wrap/command.go
+++ b/wrap/command.go
@@ -23,7 +23,7 @@ var Command = cli.Command{
 	Flags: []cli.Flag{
 		cli.StringFlag{Name: "name, n", Value: "", Usage: "The `check-name` which must be unique on a host. If it is empty it will be automatically derived."},
 		cli.BoolFlag{Name: "detail, d", Usage: "send a detailed report contains command output"},
-		cli.StringFlag{Name: "memo, m", Value: "", Usage: "`memo` of the job"},
+		cli.StringFlag{Name: "note, N", Value: "", Usage: "`note` of the job"},
 		cli.StringFlag{Name: "host, H", Value: "", Usage: "`hostID`"},
 		cli.BoolFlag{Name: "warning, w", Usage: "alerts as warning"},
 		cli.BoolFlag{Name: "auto-close, a", Usage: "automatically close an existing alert when the command success"},
@@ -87,7 +87,7 @@ func doWrap(c *cli.Context) error {
 		apibase:              apibase,
 		name:                 c.String("name"),
 		detail:               c.Bool("detail"),
-		memo:                 c.String("memo"),
+		note:                 c.String("note"),
 		warning:              c.Bool("warning"),
 		autoClose:            c.Bool("auto-close"),
 		notificationInterval: c.Duration("notification-interval"),

--- a/wrap/command.go
+++ b/wrap/command.go
@@ -38,7 +38,7 @@ func doWrap(c *cli.Context) error {
 	confFile := c.GlobalString("conf")
 	conf, err := config.LoadConfig(confFile)
 	if err != nil {
-		return err
+		logger.Logf("error", "[mkr wrap] failed to load the config %q: %s", confFile, err)
 	}
 	apibase := c.GlobalString("apibase")
 	if apibase == "" {
@@ -61,8 +61,9 @@ func doWrap(c *cli.Context) error {
 	if hostID == "" {
 		logger.Log("error", "[mkr wrap] failed to load hostID. Try to specify -host option explicitly")
 	}
-	// Since command execution has the highest priority, even when apikey or
-	// hostID is empty, we don't return errors and only output the log here.
+	// Since command execution has the highest priority, even when the config
+	// loading is failed, or apikey or hostID is empty, we don't return errors
+	// and only output the log here.
 
 	cmd := c.Args()
 	if len(cmd) > 0 && cmd[0] == "--" {

--- a/wrap/command.go
+++ b/wrap/command.go
@@ -26,7 +26,7 @@ var Command = cli.Command{
 		cli.StringFlag{Name: "memo, m", Value: "", Usage: "`memo` of the job"},
 		cli.StringFlag{Name: "host, H", Value: "", Usage: "`hostID`"},
 		cli.BoolFlag{Name: "warning, w", Usage: "alerts as warning"},
-		cli.BoolFlag{Name: "prevent-alert-auto-close, p", Usage: "alerts will not be automatically closed"},
+		cli.BoolFlag{Name: "auto-close, a", Usage: "automatically close an existing alert when the command success"},
 	},
 }
 
@@ -67,16 +67,16 @@ func doWrap(c *cli.Context) error {
 	}
 
 	return (&wrap{
-		apibase:               apibase,
-		name:                  c.String("name"),
-		detail:                c.Bool("detail"),
-		memo:                  c.String("memo"),
-		warning:               c.Bool("warning"),
-		preventAlertAutoClose: c.Bool("prevent-alert-auto-close"),
-		hostID:                hostID,
-		apikey:                apikey,
-		cmd:                   cmd,
-		outStream:             os.Stdout,
-		errStream:             os.Stderr,
+		apibase:   apibase,
+		name:      c.String("name"),
+		detail:    c.Bool("detail"),
+		memo:      c.String("memo"),
+		warning:   c.Bool("warning"),
+		autoClose: c.Bool("auto-close"),
+		hostID:    hostID,
+		apikey:    apikey,
+		cmd:       cmd,
+		outStream: os.Stdout,
+		errStream: os.Stderr,
 	}).run()
 }

--- a/wrap/command.go
+++ b/wrap/command.go
@@ -12,15 +12,17 @@ import (
 // Command is definition of mkr wrap
 var Command = cli.Command{
 	Name:      "wrap",
-	Usage:     "wrap command status",
+	Usage:     "Wrap and monitor batch jobs to run with cron etc",
 	ArgsUsage: "[--detail|-d] [--name|-n <name>] [--memo|-m <memo>] [--warning|w] -- /path/to/batch",
 	Description: `
-    wrap command line
+    Wrap a batch command with specifying it as arguments. If the command failed
+    with non-zero exit code, it sends a report to Mackerel and raises an alert.
+    It is useful for cron jobs etc.
 `,
 	Action: doWrap,
 	Flags: []cli.Flag{
-		cli.StringFlag{Name: "name, n", Value: "", Usage: "`check-name` which must be unique on a host"},
-		cli.BoolFlag{Name: "detail, d", Usage: "send a detailed report contains command output to Mackerel"},
+		cli.StringFlag{Name: "name, n", Value: "", Usage: "The `check-name` which must be unique on a host"},
+		cli.BoolFlag{Name: "detail, d", Usage: "send a detailed report contains command output"},
 		cli.StringFlag{Name: "memo, m", Value: "", Usage: "`memo` of the job"},
 		cli.StringFlag{Name: "H, host", Value: "", Usage: "`hostID`"},
 		cli.BoolFlag{Name: "warning, w", Usage: "alerts as warning"},

--- a/wrap/command.go
+++ b/wrap/command.go
@@ -28,6 +28,9 @@ var Command = cli.Command{
 		cli.BoolFlag{Name: "warning, w", Usage: "alerts as warning"},
 		cli.BoolFlag{Name: "auto-close, a", Usage: "automatically close an existing alert when the command success"},
 		cli.DurationFlag{Name: "notification-interval, I", Usage: "The notification re-sending `interval`. If it is zero, never re-send. (minimum 10 minutes)"},
+		// XXX Implementation of maxCheckAttempts is difficult because the
+		// execution interval of cron or batches are not always one-minute.
+		// This is due to the server-side logic of the Mackerel.
 	},
 }
 

--- a/wrap/command.go
+++ b/wrap/command.go
@@ -13,7 +13,7 @@ import (
 var Command = cli.Command{
 	Name:      "wrap",
 	Usage:     "Wrap and monitor batch jobs to run with cron etc",
-	ArgsUsage: "[--detail|-d] [--name|-n <name>] [--memo|-m <memo>] [--warning|w] -- /path/to/batch",
+	ArgsUsage: "[--name|-n <name>] [OPTIONS] -- /path/to/batch",
 	Description: `
     Wrap a batch command with specifying it as arguments. If the command failed
     with non-zero exit code, it sends a report to Mackerel and raises an alert.

--- a/wrap/command.go
+++ b/wrap/command.go
@@ -24,7 +24,7 @@ var Command = cli.Command{
 		cli.StringFlag{Name: "name, n", Value: "", Usage: "The `check-name` which must be unique on a host"},
 		cli.BoolFlag{Name: "detail, d", Usage: "send a detailed report contains command output"},
 		cli.StringFlag{Name: "memo, m", Value: "", Usage: "`memo` of the job"},
-		cli.StringFlag{Name: "H, host", Value: "", Usage: "`hostID`"},
+		cli.StringFlag{Name: "host, H", Value: "", Usage: "`hostID`"},
 		cli.BoolFlag{Name: "warning, w", Usage: "alerts as warning"},
 		cli.BoolFlag{Name: "prevent-alert-auto-close, p", Usage: "alerts will not be automatically closed"},
 	},

--- a/wrap/command.go
+++ b/wrap/command.go
@@ -1,0 +1,76 @@
+package wrap
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/mackerelio/mackerel-agent/config"
+	"github.com/mackerelio/mkr/logger"
+	cli "gopkg.in/urfave/cli.v1"
+)
+
+// Command is definition of mkr wrap
+var Command = cli.Command{
+	Name:      "wrap",
+	Usage:     "wrap command status",
+	ArgsUsage: "[--verbose | -v] [--name | -n <name>] [--memo | -m <memo>] -- /path/to/batch",
+	Description: `
+    wrap command line
+`,
+	Action: doWrap,
+	Flags: []cli.Flag{
+		cli.StringFlag{Name: "name, n", Value: "", Usage: "monitored `check-name` which must be unique on a host"},
+		cli.BoolFlag{Name: "verbose, v", Usage: "verbose output"},
+		cli.StringFlag{Name: "memo, m", Value: "", Usage: "`memo` of the job"},
+		cli.StringFlag{Name: "H, host", Value: "", Usage: "`hostID`"},
+		cli.BoolFlag{Name: "warning, w", Usage: "alerts as warning"},
+	},
+}
+
+func doWrap(c *cli.Context) error {
+	confFile := c.GlobalString("conf")
+	conf, err := config.LoadConfig(confFile)
+	if err != nil {
+		return err
+	}
+	apibase := c.GlobalString("apibase")
+	if apibase == "" {
+		apibase = conf.Apibase
+	}
+
+	apikey := conf.Apikey
+	if apikey == "" {
+		apikey = os.Getenv("MACKEREL_APIKEY")
+	}
+	if apikey == "" {
+		logger.Log("error", "[mkr wrap] failed to detect Mackerel APIKey. Try to specify in mackerel-agent.conf or export MACKEREL_APIKEY='<Your apikey>'")
+	}
+	hostID, _ := conf.LoadHostID()
+	if c.String("host") != "" {
+		hostID = c.String("host")
+	}
+	if hostID == "" {
+		logger.Log("error", "[mkr wrap] failed to load hostID. Try to specify -host option explicitly")
+	}
+	// Since command execution has the highest priority, even when apikey or
+	// hostID is empty, we don't return errors and only output the log here.
+
+	cmd := c.Args()
+	if len(cmd) > 0 && cmd[0] == "--" {
+		cmd = cmd[1:]
+	}
+	if len(cmd) < 1 {
+		return fmt.Errorf("no commands specified")
+	}
+
+	return (&wrap{
+		apibase: apibase,
+		name:    c.String("name"),
+		verbose: c.Bool("verbose"),
+		memo:    c.String("memo"),
+		warning: c.Bool("warning"),
+		hostID:  hostID,
+		apikey:  apikey,
+		cmd:     cmd,
+	}).run()
+}

--- a/wrap/command.go
+++ b/wrap/command.go
@@ -76,5 +76,7 @@ func doWrap(c *cli.Context) error {
 		hostID:                hostID,
 		apikey:                apikey,
 		cmd:                   cmd,
+		outStream:             os.Stdout,
+		errStream:             os.Stderr,
 	}).run()
 }

--- a/wrap/command.go
+++ b/wrap/command.go
@@ -13,14 +13,14 @@ import (
 var Command = cli.Command{
 	Name:      "wrap",
 	Usage:     "wrap command status",
-	ArgsUsage: "[--verbose | -v] [--name | -n <name>] [--memo | -m <memo>] -- /path/to/batch",
+	ArgsUsage: "[--detail|-d] [--name|-n <name>] [--memo|-m <memo>] [--warning|w] -- /path/to/batch",
 	Description: `
     wrap command line
 `,
 	Action: doWrap,
 	Flags: []cli.Flag{
-		cli.StringFlag{Name: "name, n", Value: "", Usage: "monitored `check-name` which must be unique on a host"},
-		cli.BoolFlag{Name: "verbose, v", Usage: "verbose output"},
+		cli.StringFlag{Name: "name, n", Value: "", Usage: "`check-name` which must be unique on a host"},
+		cli.BoolFlag{Name: "detail, d", Usage: "send a detailed report contains command output to Mackerel"},
 		cli.StringFlag{Name: "memo, m", Value: "", Usage: "`memo` of the job"},
 		cli.StringFlag{Name: "H, host", Value: "", Usage: "`hostID`"},
 		cli.BoolFlag{Name: "warning, w", Usage: "alerts as warning"},
@@ -66,7 +66,7 @@ func doWrap(c *cli.Context) error {
 	return (&wrap{
 		apibase: apibase,
 		name:    c.String("name"),
-		verbose: c.Bool("verbose"),
+		detail:  c.Bool("detail"),
 		memo:    c.String("memo"),
 		warning: c.Bool("warning"),
 		hostID:  hostID,

--- a/wrap/command.go
+++ b/wrap/command.go
@@ -21,12 +21,13 @@ var Command = cli.Command{
 `,
 	Action: doWrap,
 	Flags: []cli.Flag{
-		cli.StringFlag{Name: "name, n", Value: "", Usage: "The `check-name` which must be unique on a host"},
+		cli.StringFlag{Name: "name, n", Value: "", Usage: "The `check-name` which must be unique on a host. If it is empty it will be automatically derived."},
 		cli.BoolFlag{Name: "detail, d", Usage: "send a detailed report contains command output"},
 		cli.StringFlag{Name: "memo, m", Value: "", Usage: "`memo` of the job"},
 		cli.StringFlag{Name: "host, H", Value: "", Usage: "`hostID`"},
 		cli.BoolFlag{Name: "warning, w", Usage: "alerts as warning"},
 		cli.BoolFlag{Name: "auto-close, a", Usage: "automatically close an existing alert when the command success"},
+		cli.DurationFlag{Name: "notification-interval, I", Usage: "The notification re-sending `interval`. If it is zero, never re-send. (minimum 10 minutes)"},
 	},
 }
 
@@ -67,16 +68,17 @@ func doWrap(c *cli.Context) error {
 	}
 
 	return (&wrap{
-		apibase:   apibase,
-		name:      c.String("name"),
-		detail:    c.Bool("detail"),
-		memo:      c.String("memo"),
-		warning:   c.Bool("warning"),
-		autoClose: c.Bool("auto-close"),
-		hostID:    hostID,
-		apikey:    apikey,
-		cmd:       cmd,
-		outStream: os.Stdout,
-		errStream: os.Stderr,
+		apibase:              apibase,
+		name:                 c.String("name"),
+		detail:               c.Bool("detail"),
+		memo:                 c.String("memo"),
+		warning:              c.Bool("warning"),
+		autoClose:            c.Bool("auto-close"),
+		notificationInterval: c.Duration("notification-interval"),
+		hostID:               hostID,
+		apikey:               apikey,
+		cmd:                  cmd,
+		outStream:            os.Stdout,
+		errStream:            os.Stderr,
 	}).run()
 }

--- a/wrap/command.go
+++ b/wrap/command.go
@@ -52,9 +52,11 @@ func doWrap(c *cli.Context) error {
 	if apikey == "" {
 		logger.Log("error", "[mkr wrap] failed to detect Mackerel APIKey. Try to specify in mackerel-agent.conf or export MACKEREL_APIKEY='<Your apikey>'")
 	}
-	hostID, _ := conf.LoadHostID()
-	if c.String("host") != "" {
-		hostID = c.String("host")
+	var hostID string
+	if id := c.String("host"); id != "" {
+		hostID = id
+	} else {
+		hostID, _ = conf.LoadHostID()
 	}
 	if hostID == "" {
 		logger.Log("error", "[mkr wrap] failed to load hostID. Try to specify -host option explicitly")

--- a/wrap/command.go
+++ b/wrap/command.go
@@ -36,10 +36,20 @@ var Command = cli.Command{
 
 func doWrap(c *cli.Context) error {
 	confFile := c.GlobalString("conf")
-	conf, err := config.LoadConfig(confFile)
-	if err != nil {
-		logger.Logf("error", "[mkr wrap] failed to load the config %q: %s", confFile, err)
+	var conf *config.Config
+	if _, err := os.Stat(confFile); err == nil {
+		conf, err = config.LoadConfig(confFile)
+		if err != nil {
+			logger.Logf("error", "[mkr wrap] failed to load the config %q: %s", confFile, err)
+		}
+	} else {
+		logger.Logf("info", "[mkr wrap] configuraion file %q not found", confFile)
 	}
+	if conf == nil {
+		// fallback default config
+		conf = config.DefaultConfig
+	}
+
 	apibase := c.GlobalString("apibase")
 	if apibase == "" {
 		apibase = conf.Apibase

--- a/wrap/command.go
+++ b/wrap/command.go
@@ -26,6 +26,7 @@ var Command = cli.Command{
 		cli.StringFlag{Name: "memo, m", Value: "", Usage: "`memo` of the job"},
 		cli.StringFlag{Name: "H, host", Value: "", Usage: "`hostID`"},
 		cli.BoolFlag{Name: "warning, w", Usage: "alerts as warning"},
+		cli.BoolFlag{Name: "prevent-alert-auto-close, p", Usage: "alerts will not be automatically closed"},
 	},
 }
 
@@ -66,13 +67,14 @@ func doWrap(c *cli.Context) error {
 	}
 
 	return (&wrap{
-		apibase: apibase,
-		name:    c.String("name"),
-		detail:  c.Bool("detail"),
-		memo:    c.String("memo"),
-		warning: c.Bool("warning"),
-		hostID:  hostID,
-		apikey:  apikey,
-		cmd:     cmd,
+		apibase:               apibase,
+		name:                  c.String("name"),
+		detail:                c.Bool("detail"),
+		memo:                  c.String("memo"),
+		warning:               c.Bool("warning"),
+		preventAlertAutoClose: c.Bool("prevent-alert-auto-close"),
+		hostID:                hostID,
+		apikey:                apikey,
+		cmd:                   cmd,
 	}).run()
 }

--- a/wrap/command.go
+++ b/wrap/command.go
@@ -45,9 +45,9 @@ func doWrap(c *cli.Context) error {
 		apibase = conf.Apibase
 	}
 
-	apikey := conf.Apikey
+	apikey := os.Getenv("MACKEREL_APIKEY")
 	if apikey == "" {
-		apikey = os.Getenv("MACKEREL_APIKEY")
+		apikey = conf.Apikey
 	}
 	if apikey == "" {
 		logger.Log("error", "[mkr wrap] failed to detect Mackerel APIKey. Try to specify in mackerel-agent.conf or export MACKEREL_APIKEY='<Your apikey>'")

--- a/wrap/result.go
+++ b/wrap/result.go
@@ -1,0 +1,109 @@
+package wrap
+
+import (
+	"crypto/md5"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/Songmu/wrapcommander"
+)
+
+type result struct {
+	Cmd        []string
+	Name, Memo string
+
+	Output, Stdout, Stderr string `json:"-"`
+	Pid                    int
+	ExitCode               int
+	Signaled               bool
+	StartAt, EndAt         time.Time
+
+	Msg     string
+	Success bool
+}
+
+var reg = regexp.MustCompile(`[^-a-zA-Z0-9_]`)
+
+func normalizeName(str string) string {
+	return reg.ReplaceAllString(strings.TrimSpace(str), "_")
+}
+
+func (re *result) checkName() string {
+	if re.Name != "" {
+		return re.Name
+	}
+	sum := md5.Sum([]byte(strings.Join(re.Cmd, " ")))
+	return fmt.Sprintf("mkrwrap-%s-%x",
+		normalizeName(filepath.Base(re.Cmd[0])),
+		sum[0:3])
+}
+
+func (re *result) resultFile() string {
+	return filepath.Join(os.TempDir(), fmt.Sprintf("mkrwrap-%s.json", re.checkName()))
+}
+
+func (re *result) loadLastResult() (*result, error) {
+	prevRe := &result{}
+	fname := re.resultFile()
+
+	f, err := os.Open(fname)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	err = json.NewDecoder(f).Decode(prevRe)
+	return prevRe, err
+}
+
+func (re *result) saveResult() error {
+	fname := re.resultFile()
+	tmpf, err := ioutil.TempFile(filepath.Dir(fname), "tmp-mkrwrap")
+	if err != nil {
+		return err
+	}
+	defer func(tmpfname string) {
+		tmpf.Close()
+		os.Remove(tmpfname)
+	}(tmpf.Name())
+
+	if err := json.NewEncoder(tmpf).Encode(re); err != nil {
+		return err
+	}
+	if err := tmpf.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpf.Name(), fname)
+}
+
+func (re *result) errorEnd(format string, err error) *result {
+	re.Msg = fmt.Sprintf(format, err)
+	re.ExitCode = wrapcommander.ResolveExitCode(err)
+	return re
+}
+
+func (re *result) buildMsg(verbose bool) string {
+	msg := re.Msg
+	if re.Memo != "" {
+		msg += "\nMemo: " + re.Memo
+	}
+	msg += "\n% " + strings.Join(re.Cmd, " ")
+	if verbose {
+		msg += "\n" + re.Output
+	}
+	const messageLengthLimit = 1024
+	runes := []rune(msg)
+	if len(runes) > messageLengthLimit {
+		msg = string(runes[0:messageLengthLimit])
+	}
+	return msg
+}

--- a/wrap/result.go
+++ b/wrap/result.go
@@ -11,7 +11,6 @@ import (
 	"regexp"
 	"strings"
 	"text/template"
-	"time"
 
 	"github.com/Songmu/wrapcommander"
 )
@@ -20,11 +19,9 @@ type result struct {
 	Cmd        []string
 	Name, Note string
 
-	Output         string `json:"-"`
-	Pid            int
-	ExitCode       int
-	Signaled       bool
-	StartAt, EndAt time.Time
+	Output   string `json:"-"`
+	ExitCode int
+	Signaled bool
 
 	Msg     string
 	Success bool

--- a/wrap/result.go
+++ b/wrap/result.go
@@ -18,7 +18,7 @@ import (
 
 type result struct {
 	Cmd        []string
-	Name, Memo string
+	Name, Note string
 
 	Output         string `json:"-"`
 	Pid            int
@@ -94,8 +94,8 @@ func (re *result) errorEnd(format string, err error) *result {
 }
 
 const msgTplText = `{{.Msg}}
-{{- if ne .Memo "" }}
-Memo: {{.Memo}}{{end}}
+{{- if ne .Note "" }}
+Note: {{.Note}}{{end}}
 % {{.Command}}
 {{- if .Detail }}
 {{.Output}}{{end}}`
@@ -108,10 +108,10 @@ func init() {
 
 func (re *result) buildMsg(detail bool) string {
 	s := struct {
-		Msg, Memo, Command, Output string
+		Msg, Note, Command, Output string
 		Detail                     bool
 	}{
-		re.Msg, re.Memo, strings.Join(re.Cmd, " "), re.Output,
+		re.Msg, re.Note, strings.Join(re.Cmd, " "), re.Output,
 		detail,
 	}
 	buf := &bytes.Buffer{}

--- a/wrap/result.go
+++ b/wrap/result.go
@@ -20,11 +20,11 @@ type result struct {
 	Cmd        []string
 	Name, Memo string
 
-	Output, Stdout, Stderr string `json:"-"`
-	Pid                    int
-	ExitCode               int
-	Signaled               bool
-	StartAt, EndAt         time.Time
+	Output         string `json:"-"`
+	Pid            int
+	ExitCode       int
+	Signaled       bool
+	StartAt, EndAt time.Time
 
 	Msg     string
 	Success bool

--- a/wrap/result.go
+++ b/wrap/result.go
@@ -91,13 +91,13 @@ func (re *result) errorEnd(format string, err error) *result {
 	return re
 }
 
-func (re *result) buildMsg(verbose bool) string {
+func (re *result) buildMsg(detail bool) string {
 	msg := re.Msg
 	if re.Memo != "" {
 		msg += "\nMemo: " + re.Memo
 	}
 	msg += "\n% " + strings.Join(re.Cmd, " ")
-	if verbose {
+	if detail {
 		msg += "\n" + re.Output
 	}
 	const messageLengthLimit = 1024

--- a/wrap/testdata/dummy.conf
+++ b/wrap/testdata/dummy.conf
@@ -1,0 +1,1 @@
+apikey="dummy"

--- a/wrap/testdata/stub.go
+++ b/wrap/testdata/stub.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Println("Hello.")
+	os.Exit(1)
+}

--- a/wrap/wrap.go
+++ b/wrap/wrap.go
@@ -89,17 +89,17 @@ type app struct {
 }
 
 type result struct {
-	cmd        []string
-	name, memo string
+	Cmd        []string
+	Name, Memo string
 
-	output, stdout, stderr string
-	pid                    int
-	exitCode               *int
-	signaled               bool
-	startAt, endAt         time.Time
+	Output, Stdout, Stderr string
+	Pid                    int
+	ExitCode               *int
+	Signaled               bool
+	StartAt, EndAt         time.Time
 
-	msg     string
-	success bool
+	Msg     string
+	Success bool
 }
 
 func (ap *app) run() error {
@@ -110,21 +110,21 @@ func (ap *app) run() error {
 func (ap *app) runCmd() *result {
 	cmd := exec.Command(ap.cmd[0], ap.cmd[1:]...)
 	re := &result{
-		cmd:  ap.cmd,
-		name: ap.name,
-		memo: ap.memo,
+		Cmd:  ap.cmd,
+		Name: ap.name,
+		Memo: ap.memo,
 	}
 
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
-		re.msg = fmt.Sprintf("command invocation failed with follwing error: %s", err)
+		re.Msg = fmt.Sprintf("command invocation failed with follwing error: %s", err)
 		return re
 	}
 	defer stdoutPipe.Close()
 
 	stderrPipe, err := cmd.StderrPipe()
 	if err != nil {
-		re.msg = fmt.Sprintf("command invocation failed with follwing error: %s", err)
+		re.Msg = fmt.Sprintf("command invocation failed with follwing error: %s", err)
 		return re
 	}
 	defer stderrPipe.Close()
@@ -137,13 +137,13 @@ func (ap *app) runCmd() *result {
 	stdoutPipe2 := io.TeeReader(stdoutPipe, io.MultiWriter(bufStdout, bufMerged))
 	stderrPipe2 := io.TeeReader(stderrPipe, io.MultiWriter(bufStderr, bufMerged))
 
-	re.startAt = time.Now()
+	re.StartAt = time.Now()
 	err = cmd.Start()
 	if err != nil {
-		re.msg = fmt.Sprintf("command invocation failed with follwing error: %s", err)
+		re.Msg = fmt.Sprintf("command invocation failed with follwing error: %s", err)
 		return re
 	}
-	re.pid = cmd.Process.Pid
+	re.Pid = cmd.Process.Pid
 	eg := &errgroup.Group{}
 
 	eg.Go(func() error {
@@ -159,25 +159,25 @@ func (ap *app) runCmd() *result {
 	eg.Wait()
 
 	cmdErr := cmd.Wait()
-	re.endAt = time.Now()
+	re.EndAt = time.Now()
 	ex := wrapcommander.ResolveExitCode(cmdErr)
-	re.exitCode = &ex
-	if *re.exitCode > 128 {
+	re.ExitCode = &ex
+	if *re.ExitCode > 128 {
 		w, ok := wrapcommander.ErrorToWaitStatus(cmdErr)
 		if ok {
-			re.signaled = w.Signaled()
+			re.Signaled = w.Signaled()
 		}
 	}
-	if !re.signaled {
-		re.msg = fmt.Sprintf("command exited with code: %d", *re.exitCode)
+	if !re.Signaled {
+		re.Msg = fmt.Sprintf("command exited with code: %d", *re.ExitCode)
 	} else {
-		re.msg = fmt.Sprintf("command died with signal: %d", *re.exitCode&127)
+		re.Msg = fmt.Sprintf("command died with signal: %d", *re.ExitCode&127)
 	}
-	re.stdout = bufStdout.String()
-	re.stderr = bufStderr.String()
-	re.output = bufMerged.String()
+	re.Stdout = bufStdout.String()
+	re.Stderr = bufStderr.String()
+	re.Output = bufMerged.String()
 
-	re.success = *re.exitCode == 0
+	re.Success = *re.ExitCode == 0
 	return re
 }
 

--- a/wrap/wrap.go
+++ b/wrap/wrap.go
@@ -127,7 +127,7 @@ func (wr *wrap) report(re *result) error {
 		if err != nil {
 			// resultFile something went wrong.
 			// It may be no permission, broken json, not a normal file, and so on.
-			// Though it is rough, try to delete as workaround
+			// Though it is rough, try to delete as workaround.
 			err := os.RemoveAll(re.resultFile())
 			if err != nil {
 				return err

--- a/wrap/wrap.go
+++ b/wrap/wrap.go
@@ -149,9 +149,9 @@ func (wr *wrap) doReport(re *result) error {
 			checkSt = mackerel.CheckStatusCritical
 		}
 	}
-	notificationIntervalInMinutes := uint(wr.notificationInterval.Minutes())
-	if notificationIntervalInMinutes < 10 {
-		notificationIntervalInMinutes = 10
+	niInMinutes := uint(wr.notificationInterval.Minutes())
+	if 0 < niInMinutes && niInMinutes < 10 {
+		niInMinutes = 10
 	}
 
 	payload := &mackerel.CheckReports{
@@ -162,7 +162,7 @@ func (wr *wrap) doReport(re *result) error {
 				Status:               checkSt,
 				OccurredAt:           time.Now().Unix(),
 				Message:              re.buildMsg(wr.detail),
-				NotificationInterval: notificationIntervalInMinutes,
+				NotificationInterval: niInMinutes,
 			},
 		},
 	}

--- a/wrap/wrap.go
+++ b/wrap/wrap.go
@@ -127,7 +127,7 @@ func (wr *wrap) report(re *result) error {
 		if err != nil {
 			// resultFile something went wrong.
 			// It may be no permission, broken json, not a normal file, and so on.
-			// Though it rough, try to delete as workaround
+			// Though it is rough, try to delete as workaround
 			err := os.RemoveAll(re.resultFile())
 			if err != nil {
 				return err

--- a/wrap/wrap.go
+++ b/wrap/wrap.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Songmu/wrapcommander"
 	"github.com/mackerelio/mackerel-agent/config"
+	"github.com/mackerelio/mkr/logger"
 	"golang.org/x/sync/errgroup"
 	cli "gopkg.in/urfave/cli.v1"
 )
@@ -44,21 +45,24 @@ func doWrap(c *cli.Context) error {
 		apikey = os.Getenv("MACKEREL_APIKEY")
 	}
 	if apikey == "" {
-		return fmt.Errorf(`MACKEREL_APIKEY environment variable is not set. (Try "export MACKEREL_APIKEY='<Your apikey>'`)
+		logger.Log("error", "[mkr wrap] failed to detect Mackerel APIKey. Try to specify in mackerel-agent.conf or export MACKEREL_APIKEY='<Your apikey>'")
 	}
 	hostID, _ := conf.LoadHostID()
 	if c.String("host") != "" {
 		hostID = c.String("host")
 	}
 	if hostID == "" {
-		return fmt.Errorf("failed to load hostID. (Try to specify -host option explicitly)")
+		logger.Log("error", "[mkr wrap] failed to load hostID. Try to specify -host option explicitly")
 	}
+	// Since command execution has the highest priority, even when apikey or
+	// hostID is empty, we don't return errors and only output the log here.
+
 	cmd := c.Args()
 	if len(cmd) > 0 && cmd[0] == "--" {
 		cmd = cmd[1:]
 	}
 	if len(cmd) < 1 {
-		return fmt.Errorf("no command specified")
+		return fmt.Errorf("no commands specified")
 	}
 
 	return (&app{

--- a/wrap/wrap.go
+++ b/wrap/wrap.go
@@ -229,7 +229,18 @@ func (ap *app) runCmd() *result {
 
 func (ap *app) report(re *result) error {
 	if ap.apikey == "" || ap.hostID == "" {
-		return fmt.Errorf("Both apikey and hostID are needed to report result to Mackerel")
+		return fmt.Errorf("Both of apikey and hostID are needed to report result to Mackerel")
+	}
+	lastRe, err := re.loadLastResult()
+	if err != nil {
+		// resultFile something went wrong.
+		// It may be no permission, broken json, not a normal file, and so on.
+		// Though it rough, try to delete as workaround
+		err := os.RemoveAll(re.resultFile())
+		if err != nil {
+			// XXX report result here?
+			return err
+		}
 	}
 
 	fmt.Println(re.checkName())

--- a/wrap/wrap.go
+++ b/wrap/wrap.go
@@ -183,7 +183,9 @@ func (ap *app) run() error {
 		logger.Logf("error", "failed to post following report to Mackerel: %s\n%s",
 			err, ap.buildMsg(re))
 	}
-	// TODO keep original exit code
+	if !re.Success {
+		return cli.NewExitError(re.Msg, re.ExitCode)
+	}
 	return nil
 }
 

--- a/wrap/wrap.go
+++ b/wrap/wrap.go
@@ -93,7 +93,8 @@ type result struct {
 	name, memo string
 
 	output, stdout, stderr string
-	pid, exitCode          *int
+	pid                    int
+	exitCode               *int
 	signaled               bool
 	startAt, endAt         time.Time
 
@@ -103,8 +104,7 @@ type result struct {
 
 func (ap *app) run() error {
 	re := ap.runCmd()
-	_ = re
-	return nil
+	return ap.report(re)
 }
 
 func (ap *app) runCmd() *result {
@@ -143,7 +143,7 @@ func (ap *app) runCmd() *result {
 		re.msg = fmt.Sprintf("command invocation failed with follwing error: %s", err)
 		return re
 	}
-	re.pid = &cmd.Process.Pid
+	re.pid = cmd.Process.Pid
 	eg := &errgroup.Group{}
 
 	eg.Go(func() error {
@@ -179,4 +179,8 @@ func (ap *app) runCmd() *result {
 
 	re.success = *re.exitCode == 0
 	return re
+}
+
+func (ap *app) report(re *result) error {
+	return nil
 }

--- a/wrap/wrap.go
+++ b/wrap/wrap.go
@@ -1,0 +1,25 @@
+package wrap
+
+import (
+	"gopkg.in/urfave/cli.v1"
+)
+
+// CommandPlugin is definition of mkr plugin
+var Command = cli.Command{
+	Name:  "wrap",
+	Usage: "wrap command status",
+	ArgsUsage: "[--verbose | -v] [--name | -n <name>] [--memo | -m <memo>] -- /path/to/cmd",
+	Description: `
+	wrap command line
+`,
+	Action: doWrap,
+	Flags: []cli.Flag{
+		cli.StringFlag{Name: "name, n", Value: "", Usage: "monitor <name>"},
+		cli.BoolFlag{Name: "verbose, v", Usage: "Verbose output mode"},
+		cli.StringFlag{Name: "memo, m", Value: "", Usage: "monitor <memo>"},
+	},
+}
+
+func doWrap(c *cli.Context) error {
+	return nil
+}

--- a/wrap/wrap.go
+++ b/wrap/wrap.go
@@ -19,7 +19,7 @@ import (
 type wrap struct {
 	name                 string
 	detail               bool
-	memo                 string
+	note                 string
 	warning              bool
 	autoClose            bool
 	notificationInterval time.Duration
@@ -48,7 +48,7 @@ func (wr *wrap) runCmd() *result {
 	re := &result{
 		Cmd:  wr.cmd,
 		Name: wr.name,
-		Memo: wr.memo,
+		Note: wr.note,
 	}
 
 	stdoutPipe, err := cmd.StdoutPipe()

--- a/wrap/wrap.go
+++ b/wrap/wrap.go
@@ -1,25 +1,83 @@
 package wrap
 
 import (
-	"gopkg.in/urfave/cli.v1"
+	"fmt"
+	"os"
+
+	"github.com/mackerelio/mackerel-agent/config"
+	cli "gopkg.in/urfave/cli.v1"
 )
 
 // CommandPlugin is definition of mkr plugin
 var Command = cli.Command{
-	Name:  "wrap",
-	Usage: "wrap command status",
-	ArgsUsage: "[--verbose | -v] [--name | -n <name>] [--memo | -m <memo>] -- /path/to/cmd",
+	Name:      "wrap",
+	Usage:     "wrap command status",
+	ArgsUsage: "[--verbose | -v] [--name | -n <name>] [--memo | -m <memo>] -- /path/to/batch",
 	Description: `
-	wrap command line
+    wrap command line
 `,
 	Action: doWrap,
 	Flags: []cli.Flag{
 		cli.StringFlag{Name: "name, n", Value: "", Usage: "monitor <name>"},
-		cli.BoolFlag{Name: "verbose, v", Usage: "Verbose output mode"},
+		cli.BoolFlag{Name: "verbose, v", Usage: "verbose output mode"},
 		cli.StringFlag{Name: "memo, m", Value: "", Usage: "monitor <memo>"},
+		cli.StringFlag{Name: "H, host", Value: "", Usage: "<hostId>"},
+		cli.BoolFlag{Name: "warning, w", Usage: "alert as warning"},
 	},
 }
 
 func doWrap(c *cli.Context) error {
+	confFile := c.GlobalString("conf")
+	conf, err := config.LoadConfig(confFile)
+	if err != nil {
+		return err
+	}
+	apibase := c.GlobalString("apibase")
+	apikey := conf.Apikey
+	if apikey == "" {
+		apikey = os.Getenv("MACKEREL_APIKEY")
+	}
+	if apikey == "" {
+		return fmt.Errorf(`MACKEREL_APIKEY environment variable is not set. (Try "export MACKEREL_APIKEY='<Your apikey>'`)
+	}
+	hostID, _ := conf.LoadHostID()
+	if c.String("host") != "" {
+		hostID = c.String("host")
+	}
+	if hostID == "" {
+		return fmt.Errorf("failed to load hostID. (Try to specify -host option explicitly)")
+	}
+	cmd := c.Args()
+	if len(cmd) > 0 && cmd[0] == "--" {
+		cmd = cmd[1:]
+	}
+	if len(cmd) < 1 {
+		return fmt.Errorf("no command specified")
+	}
+
+	return (&app{
+		apibase: apibase,
+		name:    c.String("name"),
+		verbose: c.Bool("verbose"),
+		memo:    c.String("memo"),
+		warning: c.Bool("warning"),
+		hostID:  hostID,
+		apikey:  apikey,
+		cmd:     cmd,
+	}).run()
+}
+
+type app struct {
+	apibase string
+	name    string
+	verbose bool
+	memo    string
+	warning bool
+	hostID  string
+	apikey  string
+	cmd     []string
+}
+
+func (ap *app) run() error {
 	return nil
 }

--- a/wrap/wrap.go
+++ b/wrap/wrap.go
@@ -17,12 +17,12 @@ import (
 )
 
 type wrap struct {
-	apibase string
 	name    string
-	verbose bool
+	detail  bool
 	memo    string
 	warning bool
 	hostID  string
+	apibase string
 	apikey  string
 	cmd     []string
 }
@@ -31,7 +31,7 @@ func (wr *wrap) run() error {
 	re := wr.runCmd()
 	if err := wr.report(re); err != nil {
 		logger.Logf("error", "failed to post following report to Mackerel: %s\n%s",
-			err, re.buildMsg(wr.verbose))
+			err, re.buildMsg(wr.detail))
 	}
 	if !re.Success {
 		return cli.NewExitError(re.Msg, re.ExitCode)
@@ -152,7 +152,7 @@ func (wr *wrap) doReport(re *result) error {
 				Name:       re.checkName(),
 				Status:     checkSt,
 				OccurredAt: time.Now().Unix(),
-				Message:    re.buildMsg(wr.verbose),
+				Message:    re.buildMsg(wr.detail),
 			},
 		},
 	}

--- a/wrap/wrap.go
+++ b/wrap/wrap.go
@@ -1,10 +1,16 @@
 package wrap
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
+	"os/exec"
+	"time"
 
+	"github.com/Songmu/wrapcommander"
 	"github.com/mackerelio/mackerel-agent/config"
+	"golang.org/x/sync/errgroup"
 	cli "gopkg.in/urfave/cli.v1"
 )
 
@@ -78,6 +84,95 @@ type app struct {
 	cmd     []string
 }
 
+type result struct {
+	cmd        []string
+	name, memo string
+
+	output, stdout, stderr string
+	pid, exitCode          *int
+	signaled               bool
+	startAt, endAt         time.Time
+
+	msg     string
+	success bool
+}
+
 func (ap *app) run() error {
+	re := ap.runCmd()
+	_ = re
 	return nil
+}
+
+func (ap *app) runCmd() *result {
+	cmd := exec.Command(ap.cmd[0], ap.cmd[1:]...)
+	re := &result{
+		cmd:  ap.cmd,
+		name: ap.name,
+		memo: ap.memo,
+	}
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		re.msg = fmt.Sprintf("command invocation failed with follwing error: %s", err)
+		return re
+	}
+	defer stdoutPipe.Close()
+
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		re.msg = fmt.Sprintf("command invocation failed with follwing error: %s", err)
+		return re
+	}
+	defer stderrPipe.Close()
+
+	var (
+		bufStdout = &bytes.Buffer{}
+		bufStderr = &bytes.Buffer{}
+		bufMerged = &bytes.Buffer{}
+	)
+	stdoutPipe2 := io.TeeReader(stdoutPipe, io.MultiWriter(bufStdout, bufMerged))
+	stderrPipe2 := io.TeeReader(stderrPipe, io.MultiWriter(bufStderr, bufMerged))
+
+	re.startAt = time.Now()
+	err = cmd.Start()
+	if err != nil {
+		re.msg = fmt.Sprintf("command invocation failed with follwing error: %s", err)
+		return re
+	}
+	re.pid = &cmd.Process.Pid
+	eg := &errgroup.Group{}
+
+	eg.Go(func() error {
+		defer stdoutPipe.Close()
+		_, err := io.Copy(os.Stdout, stdoutPipe2)
+		return err
+	})
+	eg.Go(func() error {
+		defer stderrPipe.Close()
+		_, err := io.Copy(os.Stderr, stderrPipe2)
+		return err
+	})
+	eg.Wait()
+
+	cmdErr := cmd.Wait()
+	re.endAt = time.Now()
+	ex := wrapcommander.ResolveExitCode(cmdErr)
+	re.exitCode = &ex
+	if *re.exitCode > 128 {
+		w, ok := wrapcommander.ErrorToWaitStatus(cmdErr)
+		if ok {
+			re.signaled = w.Signaled()
+		}
+	}
+	if !re.signaled {
+		re.msg = fmt.Sprintf("command exited with code: %d", *re.exitCode)
+	} else {
+		re.msg = fmt.Sprintf("command died with signal: %d", *re.exitCode&127)
+	}
+	re.stdout = bufStdout.String()
+	re.stderr = bufStderr.String()
+	re.output = bufMerged.String()
+
+	re.success = *re.exitCode == 0
+	return re
 }

--- a/wrap/wrap.go
+++ b/wrap/wrap.go
@@ -26,6 +26,8 @@ type wrap struct {
 	apibase               string
 	apikey                string
 	cmd                   []string
+
+	outStream, errStream io.Writer
 }
 
 func (wr *wrap) run() error {
@@ -78,12 +80,12 @@ func (wr *wrap) runCmd() *result {
 
 	eg.Go(func() error {
 		defer stdoutPipe.Close()
-		_, err := io.Copy(os.Stdout, stdoutPipe2)
+		_, err := io.Copy(wr.outStream, stdoutPipe2)
 		return err
 	})
 	eg.Go(func() error {
 		defer stderrPipe.Close()
-		_, err := io.Copy(os.Stderr, stderrPipe2)
+		_, err := io.Copy(wr.errStream, stderrPipe2)
 		return err
 	})
 	eg.Wait()

--- a/wrap/wrap.go
+++ b/wrap/wrap.go
@@ -286,7 +286,7 @@ func (ap *app) doReport(re *result) error {
 	if re.Memo != "" {
 		msg += "\nMemo: " + re.Memo
 	}
-	msg += "\nCommand% " + strings.Join(re.Cmd, " ")
+	msg += "\n% " + strings.Join(re.Cmd, " ")
 	if ap.verbose {
 		msg += "\n" + re.Output
 	}

--- a/wrap/wrap.go
+++ b/wrap/wrap.go
@@ -17,15 +17,16 @@ import (
 )
 
 type wrap struct {
-	name      string
-	detail    bool
-	memo      string
-	warning   bool
-	autoClose bool
-	hostID    string
-	apibase   string
-	apikey    string
-	cmd       []string
+	name                 string
+	detail               bool
+	memo                 string
+	warning              bool
+	autoClose            bool
+	notificationInterval time.Duration
+	hostID               string
+	apibase              string
+	apikey               string
+	cmd                  []string
 
 	outStream, errStream io.Writer
 }
@@ -154,14 +155,20 @@ func (wr *wrap) doReport(re *result) error {
 			checkSt = mackerel.CheckStatusCritical
 		}
 	}
+	notificationIntervalInMinutes := uint(wr.notificationInterval.Minutes())
+	if notificationIntervalInMinutes < 10 {
+		notificationIntervalInMinutes = 10
+	}
+
 	payload := &mackerel.CheckReports{
 		Reports: []*mackerel.CheckReport{
 			{
-				Source:     mackerel.NewCheckSourceHost(wr.hostID),
-				Name:       re.checkName(),
-				Status:     checkSt,
-				OccurredAt: time.Now().Unix(),
-				Message:    re.buildMsg(wr.detail),
+				Source:               mackerel.NewCheckSourceHost(wr.hostID),
+				Name:                 re.checkName(),
+				Status:               checkSt,
+				OccurredAt:           time.Now().Unix(),
+				Message:              re.buildMsg(wr.detail),
+				NotificationInterval: notificationIntervalInMinutes,
 			},
 		},
 	}

--- a/wrap/wrap.go
+++ b/wrap/wrap.go
@@ -263,7 +263,7 @@ func (ap *app) report(re *result) error {
 			return err
 		}
 	}
-	if lastRe == nil || !re.Success {
+	if lastRe == nil || !lastRe.Success || !re.Success {
 		ap.doReport(re)
 	}
 	return re.saveResult()

--- a/wrap/wrap.go
+++ b/wrap/wrap.go
@@ -17,14 +17,15 @@ import (
 )
 
 type wrap struct {
-	name    string
-	detail  bool
-	memo    string
-	warning bool
-	hostID  string
-	apibase string
-	apikey  string
-	cmd     []string
+	name                  string
+	detail                bool
+	memo                  string
+	warning               bool
+	preventAlertAutoClose bool
+	hostID                string
+	apibase               string
+	apikey                string
+	cmd                   []string
 }
 
 func (wr *wrap) run() error {
@@ -130,7 +131,7 @@ func (wr *wrap) report(re *result) error {
 			return err
 		}
 	}
-	if lastRe == nil || !lastRe.Success || !re.Success {
+	if !re.Success || !wr.preventAlertAutoClose && (lastRe == nil || !lastRe.Success) {
 		return wr.doReport(re)
 	}
 	return nil

--- a/wrap/wrap.go
+++ b/wrap/wrap.go
@@ -45,6 +45,10 @@ func doWrap(c *cli.Context) error {
 		return err
 	}
 	apibase := c.GlobalString("apibase")
+	if apibase == "" {
+		apibase = conf.Apibase
+	}
+
 	apikey := conf.Apikey
 	if apikey == "" {
 		apikey = os.Getenv("MACKEREL_APIKEY")
@@ -224,6 +228,10 @@ func (ap *app) runCmd() *result {
 }
 
 func (ap *app) report(re *result) error {
+	if ap.apikey == "" || ap.hostID == "" {
+		return fmt.Errorf("Both apikey and hostID are needed to report result to Mackerel")
+	}
+
 	fmt.Println(re.checkName())
 	return nil
 }

--- a/wrap/wrap.go
+++ b/wrap/wrap.go
@@ -63,13 +63,9 @@ func (wr *wrap) runCmd() *result {
 	}
 	defer stderrPipe.Close()
 
-	var (
-		bufStdout = &bytes.Buffer{}
-		bufStderr = &bytes.Buffer{}
-		bufMerged = &bytes.Buffer{}
-	)
-	stdoutPipe2 := io.TeeReader(stdoutPipe, io.MultiWriter(bufStdout, bufMerged))
-	stderrPipe2 := io.TeeReader(stderrPipe, io.MultiWriter(bufStderr, bufMerged))
+	bufMerged := &bytes.Buffer{}
+	stdoutPipe2 := io.TeeReader(stdoutPipe, bufMerged)
+	stderrPipe2 := io.TeeReader(stderrPipe, bufMerged)
 
 	re.StartAt = time.Now()
 	err = cmd.Start()
@@ -105,8 +101,6 @@ func (wr *wrap) runCmd() *result {
 	} else {
 		re.Msg = fmt.Sprintf("command died with signal: %d", re.ExitCode&127)
 	}
-	re.Stdout = bufStdout.String()
-	re.Stderr = bufStderr.String()
 	re.Output = bufMerged.String()
 
 	re.Success = re.ExitCode == 0

--- a/wrap/wrap.go
+++ b/wrap/wrap.go
@@ -67,12 +67,10 @@ func (wr *wrap) runCmd() *result {
 	stdoutPipe2 := io.TeeReader(stdoutPipe, bufMerged)
 	stderrPipe2 := io.TeeReader(stderrPipe, bufMerged)
 
-	re.StartAt = time.Now()
 	err = cmd.Start()
 	if err != nil {
 		return re.errorEnd("command invocation failed with follwing error: %s", err)
 	}
-	re.Pid = cmd.Process.Pid
 	eg := &errgroup.Group{}
 
 	eg.Go(func() error {
@@ -88,7 +86,6 @@ func (wr *wrap) runCmd() *result {
 	eg.Wait()
 
 	cmdErr := cmd.Wait()
-	re.EndAt = time.Now()
 	re.ExitCode = wrapcommander.ResolveExitCode(cmdErr)
 	if re.ExitCode > 128 {
 		w, ok := wrapcommander.ErrorToWaitStatus(cmdErr)

--- a/wrap/wrap.go
+++ b/wrap/wrap.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Songmu/retry"
 	"github.com/Songmu/wrapcommander"
 	"github.com/mackerelio/mackerel-agent/config"
 	mackerel "github.com/mackerelio/mackerel-client-go"
@@ -263,7 +264,6 @@ func (ap *app) report(re *result) error {
 		// Though it rough, try to delete as workaround
 		err := os.RemoveAll(re.resultFile())
 		if err != nil {
-			// XXX report result here?
 			return err
 		}
 	}
@@ -310,5 +310,7 @@ func (ap *app) doReport(re *result) error {
 	if err != nil {
 		return err
 	}
-	return cli.PostCheckReports(crs)
+	return retry.Retry(3, time.Second*3, func() error {
+		return cli.PostCheckReports(crs)
+	})
 }

--- a/wrap/wrap.go
+++ b/wrap/wrap.go
@@ -2,92 +2,19 @@ package wrap
 
 import (
 	"bytes"
-	"crypto/md5"
-	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"regexp"
-	"strings"
 	"time"
 
 	"github.com/Songmu/retry"
 	"github.com/Songmu/wrapcommander"
-	"github.com/mackerelio/mackerel-agent/config"
 	mackerel "github.com/mackerelio/mackerel-client-go"
 	"github.com/mackerelio/mkr/logger"
 	"golang.org/x/sync/errgroup"
 	cli "gopkg.in/urfave/cli.v1"
 )
-
-// Command is definition of mkr wrap
-var Command = cli.Command{
-	Name:      "wrap",
-	Usage:     "wrap command status",
-	ArgsUsage: "[--verbose | -v] [--name | -n <name>] [--memo | -m <memo>] -- /path/to/batch",
-	Description: `
-    wrap command line
-`,
-	Action: doWrap,
-	Flags: []cli.Flag{
-		cli.StringFlag{Name: "name, n", Value: "", Usage: "monitored `check-name` which must be unique on a host"},
-		cli.BoolFlag{Name: "verbose, v", Usage: "verbose output"},
-		cli.StringFlag{Name: "memo, m", Value: "", Usage: "`memo` of the job"},
-		cli.StringFlag{Name: "H, host", Value: "", Usage: "`hostID`"},
-		cli.BoolFlag{Name: "warning, w", Usage: "alerts as warning"},
-	},
-}
-
-func doWrap(c *cli.Context) error {
-	confFile := c.GlobalString("conf")
-	conf, err := config.LoadConfig(confFile)
-	if err != nil {
-		return err
-	}
-	apibase := c.GlobalString("apibase")
-	if apibase == "" {
-		apibase = conf.Apibase
-	}
-
-	apikey := conf.Apikey
-	if apikey == "" {
-		apikey = os.Getenv("MACKEREL_APIKEY")
-	}
-	if apikey == "" {
-		logger.Log("error", "[mkr wrap] failed to detect Mackerel APIKey. Try to specify in mackerel-agent.conf or export MACKEREL_APIKEY='<Your apikey>'")
-	}
-	hostID, _ := conf.LoadHostID()
-	if c.String("host") != "" {
-		hostID = c.String("host")
-	}
-	if hostID == "" {
-		logger.Log("error", "[mkr wrap] failed to load hostID. Try to specify -host option explicitly")
-	}
-	// Since command execution has the highest priority, even when apikey or
-	// hostID is empty, we don't return errors and only output the log here.
-
-	cmd := c.Args()
-	if len(cmd) > 0 && cmd[0] == "--" {
-		cmd = cmd[1:]
-	}
-	if len(cmd) < 1 {
-		return fmt.Errorf("no commands specified")
-	}
-
-	return (&wrap{
-		apibase: apibase,
-		name:    c.String("name"),
-		verbose: c.Bool("verbose"),
-		memo:    c.String("memo"),
-		warning: c.Bool("warning"),
-		hostID:  hostID,
-		apikey:  apikey,
-		cmd:     cmd,
-	}).run()
-}
 
 type wrap struct {
 	apibase string
@@ -100,88 +27,11 @@ type wrap struct {
 	cmd     []string
 }
 
-type result struct {
-	Cmd        []string
-	Name, Memo string
-
-	Output, Stdout, Stderr string `json:"-"`
-	Pid                    int
-	ExitCode               int
-	Signaled               bool
-	StartAt, EndAt         time.Time
-
-	Msg     string
-	Success bool
-}
-
-var reg = regexp.MustCompile(`[^-a-zA-Z0-9_]`)
-
-func normalizeName(devName string) string {
-	return reg.ReplaceAllString(strings.TrimSpace(devName), "_")
-}
-
-func (re *result) checkName() string {
-	if re.Name != "" {
-		return re.Name
-	}
-	sum := md5.Sum([]byte(strings.Join(re.Cmd, " ")))
-	return fmt.Sprintf("mkrwrap-%s-%x",
-		normalizeName(filepath.Base(re.Cmd[0])),
-		sum[0:3])
-}
-
-func (re *result) resultFile() string {
-	return filepath.Join(os.TempDir(), fmt.Sprintf("mkrwrap-%s.json", re.checkName()))
-}
-
-func (re *result) loadLastResult() (*result, error) {
-	prevRe := &result{}
-	fname := re.resultFile()
-
-	f, err := os.Open(fname)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	defer f.Close()
-
-	err = json.NewDecoder(f).Decode(prevRe)
-	return prevRe, err
-}
-
-func (re *result) saveResult() error {
-	fname := re.resultFile()
-	tmpf, err := ioutil.TempFile(filepath.Dir(fname), "tmp-mkrwrap")
-	if err != nil {
-		return err
-	}
-	defer func(tmpfname string) {
-		tmpf.Close()
-		os.Remove(tmpfname)
-	}(tmpf.Name())
-
-	if err := json.NewEncoder(tmpf).Encode(re); err != nil {
-		return err
-	}
-	if err := tmpf.Close(); err != nil {
-		return err
-	}
-	return os.Rename(tmpf.Name(), fname)
-}
-
-func (re *result) errorEnd(format string, err error) *result {
-	re.Msg = fmt.Sprintf(format, err)
-	re.ExitCode = wrapcommander.ResolveExitCode(err)
-	return re
-}
-
 func (wr *wrap) run() error {
 	re := wr.runCmd()
 	if err := wr.report(re); err != nil {
 		logger.Logf("error", "failed to post following report to Mackerel: %s\n%s",
-			err, wr.buildMsg(re))
+			err, re.buildMsg(wr.verbose))
 	}
 	if !re.Success {
 		return cli.NewExitError(re.Msg, re.ExitCode)
@@ -286,23 +136,6 @@ func (wr *wrap) report(re *result) error {
 	return nil
 }
 
-func (wr *wrap) buildMsg(re *result) string {
-	msg := re.Msg
-	if re.Memo != "" {
-		msg += "\nMemo: " + re.Memo
-	}
-	msg += "\n% " + strings.Join(re.Cmd, " ")
-	if wr.verbose {
-		msg += "\n" + re.Output
-	}
-	const messageLengthLimit = 1024
-	runes := []rune(msg)
-	if len(runes) > messageLengthLimit {
-		msg = string(runes[0:messageLengthLimit])
-	}
-	return msg
-}
-
 func (wr *wrap) doReport(re *result) error {
 	checkSt := mackerel.CheckStatusOK
 	if !re.Success {
@@ -312,22 +145,22 @@ func (wr *wrap) doReport(re *result) error {
 			checkSt = mackerel.CheckStatusCritical
 		}
 	}
-	crs := &mackerel.CheckReports{
+	payload := &mackerel.CheckReports{
 		Reports: []*mackerel.CheckReport{
 			{
 				Source:     mackerel.NewCheckSourceHost(wr.hostID),
 				Name:       re.checkName(),
 				Status:     checkSt,
 				OccurredAt: time.Now().Unix(),
-				Message:    wr.buildMsg(re),
+				Message:    re.buildMsg(wr.verbose),
 			},
 		},
 	}
-	cli, err := mackerel.NewClientWithOptions(wr.apikey, wr.apibase, false)
+	mcli, err := mackerel.NewClientWithOptions(wr.apikey, wr.apibase, false)
 	if err != nil {
 		return err
 	}
 	return retry.Retry(3, time.Second*3, func() error {
-		return cli.PostCheckReports(crs)
+		return mcli.PostCheckReports(payload)
 	})
 }

--- a/wrap/wrap_test.go
+++ b/wrap/wrap_test.go
@@ -47,9 +47,10 @@ func TestCommand_Action(t *testing.T) {
 
 		body, _ := ioutil.ReadAll(req.Body)
 		type vr struct {
-			Name    string               `json:"name"`
-			Status  mackerel.CheckStatus `json:"status"`
-			Message string               `json:"message"`
+			Name                 string               `json:"name"`
+			Status               mackerel.CheckStatus `json:"status"`
+			Message              string               `json:"message"`
+			NotificationInterval uint                 `json:"notificationInterval,omitempty"`
 		}
 		type v struct {
 			Reports []vr `json:"reports"`
@@ -66,6 +67,7 @@ Memo: This is memo
 Hello.
 exit status 1
 `,
+					NotificationInterval: 0,
 				},
 			},
 		}

--- a/wrap/wrap_test.go
+++ b/wrap/wrap_test.go
@@ -167,3 +167,19 @@ exit status 1
 		})
 	}
 }
+
+func TestCommand_Action_withoutConf(t *testing.T) {
+	c := newWrapContext([]string{
+		"-conf=notfound", "-apibase=http://localhost", "wrap",
+		"--detail", "--",
+		"go", "run", "testdata/stub.go",
+	})
+	expect := "command exited with code: 1"
+	err := Command.Action.(func(*cli.Context) error)(c)
+	if err == nil {
+		t.Errorf("error should be occurred but nil")
+	} else if err.Error() != expect {
+		t.Errorf("The error message is different from the expected.\n   got: %s\nexpect: %s",
+			err, expect)
+	}
+}

--- a/wrap/wrap_test.go
+++ b/wrap/wrap_test.go
@@ -61,7 +61,7 @@ func TestCommand_Action(t *testing.T) {
 			Args: []string{
 				"-name=test-check",
 				"-detail",
-				"-memo", "This is memo",
+				"-note", "This is note",
 				"--",
 				"go", "run", "testdata/stub.go",
 			},
@@ -69,7 +69,7 @@ func TestCommand_Action(t *testing.T) {
 				Name:   "test-check",
 				Status: mackerel.CheckStatusCritical,
 				Message: `command exited with code: 1
-Memo: This is memo
+Note: This is note
 % go run testdata/stub.go
 Hello.
 exit status 1

--- a/wrap/wrap_test.go
+++ b/wrap/wrap_test.go
@@ -1,0 +1,97 @@
+package wrap
+
+import (
+	"encoding/json"
+	"flag"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	mackerel "github.com/mackerelio/mackerel-client-go"
+	cli "gopkg.in/urfave/cli.v1"
+)
+
+func newWrapContext(args []string) *cli.Context {
+	app := cli.NewApp()
+	parentFs := flag.NewFlagSet("mockmkr", flag.ContinueOnError)
+	for _, f := range []cli.Flag{
+		cli.StringFlag{Name: "conf"}, cli.StringFlag{Name: "apibase"},
+	} {
+		f.Apply(parentFs)
+	}
+	parentFs.Parse(args)
+	for i, v := range parentFs.Args() {
+		if v == "wrap" {
+			args = parentFs.Args()[i+1:]
+			break
+		}
+	}
+	parentCtx := cli.NewContext(app, parentFs, nil)
+
+	fs := flag.NewFlagSet("mockwrap", flag.ContinueOnError)
+	for _, f := range Command.Flags {
+		f.Apply(fs)
+	}
+	fs.Parse(args)
+	return cli.NewContext(app, fs, parentCtx)
+}
+
+func TestCommand_Action(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		reqPath := "/api/v0/monitoring/checks/report"
+		if req.URL.Path != reqPath {
+			t.Errorf("request URL should be %s but: %s", reqPath, req.URL.Path)
+		}
+
+		body, _ := ioutil.ReadAll(req.Body)
+		type vr struct {
+			Name    string               `json:"name"`
+			Status  mackerel.CheckStatus `json:"status"`
+			Message string               `json:"message"`
+		}
+		type v struct {
+			Reports []vr `json:"reports"`
+		}
+		var got v
+		expect := v{
+			Reports: []vr{
+				{
+					Name:   "test-check",
+					Status: mackerel.CheckStatusCritical,
+					Message: `command exited with code: 1
+Memo: This is memo
+% go run testdata/stub.go
+Hello.
+exit status 1
+`,
+				},
+			},
+		}
+
+		err := json.Unmarshal(body, &got)
+		if err != nil {
+			t.Fatal("request body should be decoded as json", string(body))
+		}
+
+		if !reflect.DeepEqual(got, expect) {
+			t.Errorf("something went wrong.\n   got: %+v,\nexpect: %+v", got, expect)
+		}
+
+		res.Header()["Content-Type"] = []string{"application/json"}
+		json.NewEncoder(res).Encode(map[string]bool{
+			"success": true,
+		})
+	}))
+	defer ts.Close()
+
+	c := newWrapContext([]string{"-conf=testdata/dummy.conf", "-apibase", ts.URL, "wrap",
+		"-name=test-check",
+		"-detail",
+		"-memo", "This is memo",
+		"--",
+		"go", "run", "testdata/stub.go",
+	})
+	Command.Action.(func(*cli.Context) error)(c)
+}


### PR DESCRIPTION
Wrap a batch command with specifying it as arguments. If the command failed
with non-zero exit code, it sends a report to Mackerel and raises an alert.
It is useful for cron jobs etc.

## usage

```
% mkr wrap -- /path/to/your-batch
```

## files

- command.go
  - entry point of the `wrap` subcommand
- wrap.go
  - main logic is here
- result.go
  - define `type result` to represent the command result