### PR TITLE
Add out stream argument to format.PrettyPrintJSON

### DIFF
--- a/alerts.go
+++ b/alerts.go
@@ -249,7 +249,7 @@ func doAlertsRetrieve(c *cli.Context) error {
 	withClosed := c.Bool("with-closed")
 	alerts, err := fetchAlerts(client, withClosed, getAlertsLimit(c, withClosed))
 	logger.DieIf(err)
-	format.PrettyPrintJSON(alerts)
+	format.PrettyPrintJSON(os.Stdout, alerts)
 	return nil
 }
 
@@ -383,7 +383,7 @@ func doAlertsClose(c *cli.Context) error {
 
 		logger.Log("Alert closed", alertID)
 		if isVerbose == true {
-			format.PrettyPrintJSON(alert)
+			format.PrettyPrintJSON(os.Stdout, alert)
 		}
 	}
 	return nil

--- a/annotations.go
+++ b/annotations.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	mkr "github.com/mackerelio/mackerel-client-go"
 	"github.com/mackerelio/mkr/format"
 	"github.com/mackerelio/mkr/logger"
@@ -126,7 +128,7 @@ func doAnnotationsCreate(c *cli.Context) error {
 		Roles:       roles,
 	})
 	logger.DieIf(err)
-	format.PrettyPrintJSON(annotation)
+	format.PrettyPrintJSON(os.Stdout, annotation)
 	return nil
 }
 
@@ -153,7 +155,7 @@ func doAnnotationsList(c *cli.Context) error {
 	client := mackerelclient.NewFromContext(c)
 	annotations, err := client.FindGraphAnnotations(service, from, to)
 	logger.DieIf(err)
-	format.PrettyPrintJSON(annotations)
+	format.PrettyPrintJSON(os.Stdout, annotations)
 	return nil
 }
 
@@ -196,7 +198,7 @@ func doAnnotationsUpdate(c *cli.Context) error {
 		Roles:       roles,
 	})
 	logger.DieIf(err)
-	format.PrettyPrintJSON(annotation)
+	format.PrettyPrintJSON(os.Stdout, annotation)
 	return nil
 }
 
@@ -211,6 +213,6 @@ func doAnnotationsDelete(c *cli.Context) error {
 	client := mackerelclient.NewFromContext(c)
 	annotation, err := client.DeleteGraphAnnotation(annotationID)
 	logger.DieIf(err)
-	format.PrettyPrintJSON(annotation)
+	format.PrettyPrintJSON(os.Stdout, annotation)
 	return nil
 }

--- a/commands.go
+++ b/commands.go
@@ -174,9 +174,9 @@ func doStatus(c *cli.Context) error {
 	logger.DieIf(err)
 
 	if isVerbose {
-		format.PrettyPrintJSON(host)
+		format.PrettyPrintJSON(os.Stdout, host)
 	} else {
-		format.PrettyPrintJSON(&format.Host{
+		format.PrettyPrintJSON(os.Stdout, &format.Host{
 			ID:            host.ID,
 			Name:          host.Name,
 			DisplayName:   host.DisplayName,
@@ -321,12 +321,12 @@ func doMetrics(c *cli.Context) error {
 		metricValue, err := client.FetchHostMetricValues(optHostID, optMetricName, from, to)
 		logger.DieIf(err)
 
-		format.PrettyPrintJSON(metricValue)
+		format.PrettyPrintJSON(os.Stdout, metricValue)
 	} else if optService != "" {
 		metricValue, err := client.FetchServiceMetricValues(optService, optMetricName, from, to)
 		logger.DieIf(err)
 
-		format.PrettyPrintJSON(metricValue)
+		format.PrettyPrintJSON(os.Stdout, metricValue)
 	} else {
 		cli.ShowCommandHelp(c, "metrics")
 		os.Exit(1)
@@ -353,7 +353,7 @@ func doFetch(c *cli.Context) error {
 		}
 	}
 
-	format.PrettyPrintJSON(allMetricValues)
+	format.PrettyPrintJSON(os.Stdout, allMetricValues)
 	return nil
 }
 
@@ -389,6 +389,6 @@ func doRetire(c *cli.Context) error {
 func doServices(c *cli.Context) error {
 	services, err := mackerelclient.NewFromContext(c).FindServices()
 	logger.DieIf(err)
-	format.PrettyPrintJSON(services)
+	format.PrettyPrintJSON(os.Stdout, services)
 	return nil
 }

--- a/format/format.go
+++ b/format/format.go
@@ -3,7 +3,7 @@ package format
 import (
 	"encoding/json"
 	"fmt"
-	"os"
+	"io"
 	"strings"
 	"time"
 
@@ -24,8 +24,8 @@ type Host struct {
 }
 
 // PrettyPrintJSON output indented json via stdout.
-func PrettyPrintJSON(src interface{}) error {
-	_, err := fmt.Fprintln(os.Stdout, JSONMarshalIndent(src, "", "    "))
+func PrettyPrintJSON(outStream io.Writer, src interface{}) error {
+	_, err := fmt.Fprintln(outStream, JSONMarshalIndent(src, "", "    "))
 	return err
 }
 

--- a/hosts/app.go
+++ b/hosts/app.go
@@ -40,7 +40,7 @@ func (ha *hostApp) run() error {
 		}
 		return t.Execute(os.Stdout, hosts)
 	case ha.verbose:
-		return format.PrettyPrintJSON(hosts)
+		return format.PrettyPrintJSON(os.Stdout, hosts)
 	default:
 		var hostsFormat []*format.Host
 		for _, host := range hosts {
@@ -55,6 +55,6 @@ func (ha *hostApp) run() error {
 				IPAddresses:   host.IPAddresses(),
 			})
 		}
-		return format.PrettyPrintJSON(hostsFormat)
+		return format.PrettyPrintJSON(os.Stdout, hostsFormat)
 	}
 }

--- a/monitors.go
+++ b/monitors.go
@@ -159,7 +159,7 @@ func doMonitorsList(c *cli.Context) error {
 	monitors, err := mackerelclient.NewFromContext(c).FindMonitors()
 	logger.DieIf(err)
 
-	format.PrettyPrintJSON(monitors)
+	format.PrettyPrintJSON(os.Stdout, monitors)
 	return nil
 }
 
@@ -173,7 +173,7 @@ func doMonitorsPull(c *cli.Context) error {
 	monitorSaveRules(monitors, filePath)
 
 	if isVerbose {
-		format.PrettyPrintJSON(monitors)
+		format.PrettyPrintJSON(os.Stdout, monitors)
 	}
 
 	if filePath == "" {

--- a/org.go
+++ b/org.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/mackerelio/mkr/format"
 	"github.com/mackerelio/mkr/logger"
 	"github.com/mackerelio/mkr/mackerelclient"
@@ -22,6 +24,6 @@ func doOrgRetrieve(c *cli.Context) error {
 
 	org, err := client.GetOrg()
 	logger.DieIf(err)
-	format.PrettyPrintJSON(org)
+	format.PrettyPrintJSON(os.Stdout, org)
 	return nil
 }


### PR DESCRIPTION
This is the first step to improve test coverage.

Future plans:

- Split each command to packages (like hostApp)
- Each app has client interface so that we can mock in tests
- Each app has outStream io.Writer so that we can test
- Write much more and more tests!

I think we can start with hosts  subcommand or org subcommand (which is very easy!).