### PR TITLE
Introduce Client interface for Mackerel API

### DIFF
--- a/hosts/app.go
+++ b/hosts/app.go
@@ -6,10 +6,11 @@ import (
 
 	mkr "github.com/mackerelio/mackerel-client-go"
 	"github.com/mackerelio/mkr/format"
+	"github.com/mackerelio/mkr/mackerelclient"
 )
 
 type hostApp struct {
-	cli *mkr.Client
+	cli mackerelclient.Client
 
 	verbose bool
 

--- a/hosts/app.go
+++ b/hosts/app.go
@@ -4,7 +4,8 @@ import (
 	"os"
 	"text/template"
 
-	mkr "github.com/mackerelio/mackerel-client-go"
+	mackerel "github.com/mackerelio/mackerel-client-go"
+
 	"github.com/mackerelio/mkr/format"
 	"github.com/mackerelio/mkr/mackerelclient"
 )
@@ -23,7 +24,7 @@ type hostApp struct {
 }
 
 func (ha *hostApp) run() error {
-	hosts, err := ha.cli.FindHosts(&mkr.FindHostsParam{
+	hosts, err := ha.cli.FindHosts(&mackerel.FindHostsParam{
 		Name:     ha.name,
 		Service:  ha.service,
 		Roles:    ha.roles,

--- a/hosts/command.go
+++ b/hosts/command.go
@@ -1,8 +1,9 @@
 package hosts
 
 import (
-	"github.com/mackerelio/mkr/mackerelclient"
 	cli "gopkg.in/urfave/cli.v1"
+
+	"github.com/mackerelio/mkr/mackerelclient"
 )
 
 // Command is definition of mkr hosts subcommand

--- a/mackerelclient/client.go
+++ b/mackerelclient/client.go
@@ -1,0 +1,8 @@
+package mackerelclient
+
+import mackerel "github.com/mackerelio/mackerel-client-go"
+
+// Client represents a client of Mackerel API
+type Client interface {
+	FindHosts(param *mackerel.FindHostsParam) ([]*mackerel.Host, error)
+}

--- a/mackerelclient/mock_client.go
+++ b/mackerelclient/mock_client.go
@@ -1,0 +1,46 @@
+package mackerelclient
+
+import mackerel "github.com/mackerelio/mackerel-client-go"
+
+// MockClient represents a mock client of Mackerel API
+type MockClient struct {
+	findHostsCallback func(param *mackerel.FindHostsParam) ([]*mackerel.Host, error)
+}
+
+// MockClientOption represents an option of mock client of Mackerel API
+type MockClientOption func(*MockClient)
+
+// NewMockClient creates a new mock client of Mackerel API
+func NewMockClient(opts ...MockClientOption) *MockClient {
+	client := &MockClient{}
+	for _, opt := range opts {
+		client.ApplyOption(opt)
+	}
+	return client
+}
+
+// ApplyOption applies a mock client option
+func (c *MockClient) ApplyOption(opt MockClientOption) {
+	opt(c)
+}
+
+type errCallbackNotFound string
+
+func (err errCallbackNotFound) Error() string {
+	return string(err) + " callback not found"
+}
+
+// FindHosts ...
+func (c *MockClient) FindHosts(param *mackerel.FindHostsParam) ([]*mackerel.Host, error) {
+	if c.findHostsCallback != nil {
+		return c.findHostsCallback(param)
+	}
+	return nil, errCallbackNotFound("FindHosts")
+}
+
+// MockFindHosts returns an option to set the callback of FindHosts
+func MockFindHosts(callback func(param *mackerel.FindHostsParam) ([]*mackerel.Host, error)) MockClientOption {
+	return func(c *MockClient) {
+		c.findHostsCallback = callback
+	}
+}

--- a/mackerelclient/new.go
+++ b/mackerelclient/new.go
@@ -11,7 +11,7 @@ import (
 )
 
 // New returns new mackerel client
-func New(conffile, apibase string) (*mkr.Client, error) {
+func New(conffile, apibase string) (Client, error) {
 	apikey := os.Getenv("MACKEREL_APIKEY")
 	var conf *config.Config
 	if apikey == "" {

--- a/mackerelclient/new.go
+++ b/mackerelclient/new.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/mackerelio/mackerel-agent/config"
-	mkr "github.com/mackerelio/mackerel-client-go"
-	"github.com/mackerelio/mkr/logger"
 	cli "gopkg.in/urfave/cli.v1"
+
+	"github.com/mackerelio/mackerel-agent/config"
+	mackerel "github.com/mackerelio/mackerel-client-go"
+
+	"github.com/mackerelio/mkr/logger"
 )
 
 // New returns new mackerel client
@@ -34,11 +36,11 @@ func New(conffile, apibase string) (Client, error) {
 		}
 		apibase = conf.Apibase
 	}
-	return mkr.NewClientWithOptions(apikey, apibase, os.Getenv("DEBUG") != "")
+	return mackerel.NewClientWithOptions(apikey, apibase, os.Getenv("DEBUG") != "")
 }
 
 // NewFromContext returns mackerel client from cli.Context
-func NewFromContext(c *cli.Context) *mkr.Client {
+func NewFromContext(c *cli.Context) *mackerel.Client {
 	confFile := c.GlobalString("conf")
 	apiBase := c.GlobalString("apibase")
 	apiKey := LoadApikeyFromEnvOrConfig(confFile)
@@ -53,8 +55,8 @@ func NewFromContext(c *cli.Context) *mkr.Client {
 		apiBase = LoadApibaseFromConfigWithFallback(confFile)
 	}
 
-	mackerel, err := mkr.NewClientWithOptions(apiKey, apiBase, os.Getenv("DEBUG") != "")
+	client, err := mackerel.NewClientWithOptions(apiKey, apiBase, os.Getenv("DEBUG") != "")
 	logger.DieIf(err)
 
-	return mackerel
+	return client
 }


### PR DESCRIPTION
In order to write mock tests, I want to introduce interface for Mackerel API Client. This is much like https://github.com/mackerelio/mackerel-container-agent/blob/2d193452f862b96a61364e95e4dbf450bb6ac17e/api/client.go.

Future plans:

- Split subcommands to packages (like hostsApp)
- Add methods to the Client interface if required by the commands.
- Add mock tests.
- Remove mackerelclient.NewFromContext.

I want to change import alias mkr to mackerel, so that we can change the top directory of this repository to mkr package (move main.go to cmd/mkr/).