### PR TITLE
[nit] Fix link in command helps to english versions

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -103,7 +103,7 @@ var commandMetrics = cli.Command{
 	Description: `
     Fetch metric values of 'host metric' or 'service metric'.
     Requests "/api/v0/hosts/<hostId>/metrics" or "/api/v0/services/<serviceName>/tsdb".
-		See https://mackerel.io/api-docs/entry/host-metrics#get, https://mackerel.io/ja/api-docs/entry/service-metrics#get.
+    See https://mackerel.io/api-docs/entry/host-metrics#get, https://mackerel.io/api-docs/entry/service-metrics#get.
 `,
 	Action: doMetrics,
 	Flags: []cli.Flag{

--- a/dashboards.go
+++ b/dashboards.go
@@ -27,7 +27,7 @@ var commandDashboards = cli.Command{
 			ArgsUsage: "[--print | -p] <file>",
 			Description: `
     A custom dashboard is registered from a yaml file.
-    Requests "POST /api/v0/dashboards". See https://mackerel.io/ja/api-docs/entry/dashboards#create.
+    Requests "POST /api/v0/dashboards". See https://mackerel.io/api-docs/entry/dashboards#create.
 `,
 			Action: doGenerateDashboards,
 			Flags: []cli.Flag{


### PR DESCRIPTION
I found some links in the command help are the links to Japanese version.