### PR TITLE
Improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-BIN = mkr
-VERSION = 0.35.1
-CURRENT_REVISION = $(shell git rev-parse --short HEAD)
-BUILD_LDFLAGS = "-w -s -X main.gitcommit=$(CURRENT_REVISION)"
+BIN := mkr
+VERSION := 0.35.1
+CURRENT_REVISION := $(shell git rev-parse --short HEAD)
+BUILD_LDFLAGS := "-w -s -X main.gitcommit=$(CURRENT_REVISION)"
 
 .PHONY: all
 all: clean cross lint gofmt test rpm deb

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 BIN = mkr
 VERSION = 0.35.1
 CURRENT_REVISION = $(shell git rev-parse --short HEAD)
+BUILD_LDFLAGS = "-w -s -X main.gitcommit=$(CURRENT_REVISION)"
 
 all: clean cross lint gofmt test rpm deb
 
@@ -19,7 +20,7 @@ test: test-deps
 	go test -v ./...
 
 build: deps
-	go build -ldflags "-w -s -X main.gitcommit=$(CURRENT_REVISION)" -o $(BIN) .
+	go build -ldflags=$(BUILD_LDFLAGS) -o $(BIN) .
 
 lint: test-deps
 	go vet ./...
@@ -33,7 +34,7 @@ gofmt: test-deps
 
 cross: devel-deps
 	goxz -d snapshot -os darwin,linux -arch 386,amd64 \
-	  -build-ldflags "-X main.gitcommit=$(CURRENT_REVISION)"
+	  -build-ldflags=$(BUILD_LDFLAGS)
 
 rpm: rpm-v1 rpm-v2
 

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ release: check-release-deps
 
 .PHONY: clean
 clean:
-	rm -fr build
+	rm -fr build snapshot
 	go clean
 
 .PHONY: cover


### PR DESCRIPTION
- Add -w -s in make cross too.
- Move phony targets (ref: Clark Grubb's Makefile style guide)
- `:=` is preferred than `=` in performance (especially when referred multiple times)

Before
```
~/.go/src/github.com/mackerelio/mkr ls -lh snapshot/
total 66824
-rw-r--r--  1 itchyny  staff   7.5M Mar 20 17:42 mkr_darwin_386.zip
-rw-r--r--  1 itchyny  staff   7.7M Mar 20 17:42 mkr_darwin_amd64.zip
-rw-r--r--  1 itchyny  staff   7.6M Mar 20 17:42 mkr_linux_386.tar.gz
-rw-r--r--  1 itchyny  staff   7.7M Mar 20 17:42 mkr_linux_amd64.tar.gz
```

After
```
~/.go/src/github.com/mackerelio/mkr ls -lh snapshot/
total 37936
-rw-r--r--  1 itchyny  staff   4.5M Mar 20 17:59 mkr_darwin_386.zip
-rw-r--r--  1 itchyny  staff   4.7M Mar 20 17:59 mkr_darwin_amd64.zip
-rw-r--r--  1 itchyny  staff   4.2M Mar 20 17:59 mkr_linux_386.tar.gz
-rw-r--r--  1 itchyny  staff   4.4M Mar 20 17:59 mkr_linux_amd64.tar.gz
```