### PR TITLE
[wrap] Improve message truncation algorithm

### DIFF
--- a/wrap/result.go
+++ b/wrap/result.go
@@ -113,11 +113,25 @@ func (re *result) buildMsg(detail bool) string {
 	}
 	buf := &bytes.Buffer{}
 	template.Must(msgTpl.Clone()).Execute(buf, s)
-	msg := buf.String()
-	const messageLengthLimit = 1024
-	runes := []rune(msg)
-	if len(runes) > messageLengthLimit {
-		msg = string(runes[0:messageLengthLimit])
+	const messageLengthLimit = 1024 // https://mackerel.io/api-docs/entry/check-monitoring#post
+	return truncate(buf.String(), messageLengthLimit, "\n...\n")
+}
+
+func truncate(src string, limit int, sep string) string {
+	rs := []rune(src)
+	if len(rs) <= limit {
+		return src
 	}
-	return msg
+	seprs := []rune(sep)
+	var i int
+	rest := limit - len(seprs)
+	if 0 < rest {
+		i += rest / 2
+		rest -= rest / 2
+	}
+	i += copy(rs[i:], seprs)
+	if 0 < rest {
+		copy(rs[i:], rs[len(rs)-rest:])
+	}
+	return string(rs[:limit])
 }

--- a/wrap/testdata/long.go
+++ b/wrap/testdata/long.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	for i := 0; i < 100; i++ {
+		fmt.Println("Hello world!")
+	}
+	os.Exit(1)
+}

--- a/wrap/wrap_test.go
+++ b/wrap/wrap_test.go
@@ -80,6 +80,30 @@ exit status 1
 			ExitCode: 1,
 		},
 		{
+			Name: "long output",
+			Args: []string{
+				"-name=test-check",
+				"-detail",
+				"-note", "This is note",
+				"--",
+				"go", "run", "testdata/long.go",
+			},
+			Result: testResult{
+				Name:   "test-check",
+				Status: mackerel.CheckStatusCritical,
+				Message: `command exited with code: 1
+Note: This is note
+% go run testdata/long.go
+` + strings.Repeat("Hello world!\n", 33) + `Hello w
+...
+!
+` + strings.Repeat("Hello world!\n", 38) + `exit status 1
+`,
+				NotificationInterval: 0,
+			},
+			ExitCode: 1,
+		},
+		{
 			Name: "notification interval",
 			Args: []string{
 				"-name=test-check2",


### PR DESCRIPTION
It would be useful to show both heading and leading messages of the output. The length is limited to the spec of api https://mackerel.io/api-docs/entry/check-monitoring#post.
Resolves #199.
