### PR TITLE
upgrade builder image and enable go modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM golang:alpine3.7 AS builder
+FROM golang:1.12-alpine AS builder
 RUN apk add --no-cache make git
 WORKDIR /go/src/github.com/mackerelio/mkr/
 COPY . .
+ENV GO111MODULE=on
 RUN make build
 
-FROM alpine:3.7
+FROM alpine:3.9
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /go/src/github.com/mackerelio/mkr/mkr /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/mkr"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,10 @@ version: "{build}"
 clone_folder: c:\gopath\src\github.com\mackerelio\mkr
 environment:
   GOPATH: c:\gopath
-  GOROOT: c:\go111-x86
+  GOROOT: c:\go112
+  GO111MODULE: on
 build: off
 install:
   - set PATH=%GOROOT%\bin;%GOPATH%\bin;C:\msys64\mingw64\bin;%PATH%
 test_script:
-  - go get -d -v -t ./...
   - go test -v ./...


### PR DESCRIPTION
*golang:alpine3.7* image's Go version is 1.10.
This version don't support Go Modules.

related pull requests:

* #205
* #207 