### PR TITLE
Stop using alias imports for mackerel-client-go for simplicity

### DIFF
--- a/alerts_test.go
+++ b/alerts_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	mkr "github.com/mackerelio/mackerel-client-go"
+	"github.com/mackerelio/mackerel-client-go"
 )
 
 func TestFormatJoinedAlert(t *testing.T) {
@@ -23,73 +23,73 @@ func TestFormatJoinedAlert(t *testing.T) {
 	}{
 		{
 			&alertSet{
-				&mkr.Alert{ID: "2tZhm", Type: "connectivity", Status: "CRITICAL", HostID: "3XYyG", MonitorID: "5rXR3", OpenedAt: 100},
-				&mkr.Host{ID: "3XYyG", Name: "app.example.com", Roles: mkr.Roles{"foo": {"bar", "baz"}}, Status: "working"},
-				&mkr.MonitorConnectivity{ID: "5rXR3", Type: "connectivity", Name: "connectivity"},
+				&mackerel.Alert{ID: "2tZhm", Type: "connectivity", Status: "CRITICAL", HostID: "3XYyG", MonitorID: "5rXR3", OpenedAt: 100},
+				&mackerel.Host{ID: "3XYyG", Name: "app.example.com", Roles: mackerel.Roles{"foo": {"bar", "baz"}}, Status: "working"},
+				&mackerel.MonitorConnectivity{ID: "5rXR3", Type: "connectivity", Name: "connectivity"},
 			},
 			"2tZhm 1970-01-01 00:01:40 CRITICAL connectivity app.example.com working [foo:bar,baz]",
 		},
 		{
 			&alertSet{
-				&mkr.Alert{ID: "2tZhm", Type: "host", Status: "CRITICAL", HostID: "3XYyG", MonitorID: "5rXR3", Value: 15.7, OpenedAt: 200},
-				&mkr.Host{ID: "3XYyG", Name: "app.example.com", Roles: mkr.Roles{"foo": {"bar", "baz"}}, Status: "working"},
-				&mkr.MonitorHostMetric{ID: "5rXR3", Type: "host", Name: "All::loadavg5", Metric: "loadavg5", Warning: pfloat64(8.0), Critical: pfloat64(12.0), Operator: ">"},
+				&mackerel.Alert{ID: "2tZhm", Type: "host", Status: "CRITICAL", HostID: "3XYyG", MonitorID: "5rXR3", Value: 15.7, OpenedAt: 200},
+				&mackerel.Host{ID: "3XYyG", Name: "app.example.com", Roles: mackerel.Roles{"foo": {"bar", "baz"}}, Status: "working"},
+				&mackerel.MonitorHostMetric{ID: "5rXR3", Type: "host", Name: "All::loadavg5", Metric: "loadavg5", Warning: pfloat64(8.0), Critical: pfloat64(12.0), Operator: ">"},
 			},
 			"2tZhm 1970-01-01 00:03:20 CRITICAL All::loadavg5 loadavg5 15.70 > 12.00 app.example.com working [foo:bar,baz]",
 		},
 		{
 			&alertSet{
-				&mkr.Alert{ID: "2tZhm", Type: "service", Status: "WARNING", MonitorID: "5rXR3", Value: 15.7, OpenedAt: 300},
+				&mackerel.Alert{ID: "2tZhm", Type: "service", Status: "WARNING", MonitorID: "5rXR3", Value: 15.7, OpenedAt: 300},
 				nil,
-				&mkr.MonitorServiceMetric{ID: "5rXR3", Type: "service", Service: "ServiceFoo", Name: "bar.baz monitor", Metric: "custom.bar.baz", Warning: pfloat64(10.0), Critical: pfloat64(20.0), Operator: ">"},
+				&mackerel.MonitorServiceMetric{ID: "5rXR3", Type: "service", Service: "ServiceFoo", Name: "bar.baz monitor", Metric: "custom.bar.baz", Warning: pfloat64(10.0), Critical: pfloat64(20.0), Operator: ">"},
 			},
 			"2tZhm 1970-01-01 00:05:00 WARNING bar.baz monitor ServiceFoo custom.bar.baz 15.70 > 10.00",
 		},
 		{
 			&alertSet{
-				&mkr.Alert{ID: "2tZhm", Type: "external", Status: "CRITICAL", MonitorID: "5rXR3", Value: 2500, Message: "200", OpenedAt: 400},
+				&mackerel.Alert{ID: "2tZhm", Type: "external", Status: "CRITICAL", MonitorID: "5rXR3", Value: 2500, Message: "200", OpenedAt: 400},
 				nil,
-				&mkr.MonitorExternalHTTP{ID: "5rXR3", Type: "external", Name: "Example Domain", URL: "https://example.com", ResponseTimeWarning: pfloat64(500), ResponseTimeCritical: pfloat64(1000), ResponseTimeDuration: puint64(5)},
+				&mackerel.MonitorExternalHTTP{ID: "5rXR3", Type: "external", Name: "Example Domain", URL: "https://example.com", ResponseTimeWarning: pfloat64(500), ResponseTimeCritical: pfloat64(1000), ResponseTimeDuration: puint64(5)},
 			},
 			"2tZhm 1970-01-01 00:06:40 CRITICAL Example Domain https://example.com 2500.00 > 1000.00 msec, status:200",
 		},
 		{
 			&alertSet{
-				&mkr.Alert{ID: "2tZhm", Type: "expression", Status: "WARNING", MonitorID: "5rXR3", Value: 15.7, OpenedAt: 500},
+				&mackerel.Alert{ID: "2tZhm", Type: "expression", Status: "WARNING", MonitorID: "5rXR3", Value: 15.7, OpenedAt: 500},
 				nil,
-				&mkr.MonitorExpression{ID: "5rXR3", Type: "expression", Name: "Max loadavg5 monitor", Expression: "max(  \n  roleSlots(  \n    'service:role',\n    'loadavg5'\n  )\n)\n", Warning: pfloat64(10.0), Critical: pfloat64(20.0), Operator: ">"},
+				&mackerel.MonitorExpression{ID: "5rXR3", Type: "expression", Name: "Max loadavg5 monitor", Expression: "max(  \n  roleSlots(  \n    'service:role',\n    'loadavg5'\n  )\n)\n", Warning: pfloat64(10.0), Critical: pfloat64(20.0), Operator: ">"},
 			},
 			"2tZhm 1970-01-01 00:08:20 WARNING Max loadavg5 monitor max(roleSlots('service:role', 'loadavg5')) 15.70 > 10.00",
 		},
 		{
 			&alertSet{
-				&mkr.Alert{ID: "2tZhm", Type: "check", Status: "WARNING", MonitorID: "5rXR3", OpenedAt: 500, Message: "Short check monitoring description"},
-				&mkr.Host{ID: "3XYyG", Name: "app.example.com", Roles: mkr.Roles{"foo": {"bar", "baz"}}, Status: "working"},
+				&mackerel.Alert{ID: "2tZhm", Type: "check", Status: "WARNING", MonitorID: "5rXR3", OpenedAt: 500, Message: "Short check monitoring description"},
+				&mackerel.Host{ID: "3XYyG", Name: "app.example.com", Roles: mackerel.Roles{"foo": {"bar", "baz"}}, Status: "working"},
 				nil,
 			},
 			"2tZhm 1970-01-01 00:08:20 WARNING Short check monitoring description app.example.com working [foo:bar,baz]",
 		},
 		{
 			&alertSet{
-				&mkr.Alert{ID: "2tZhm", Type: "check", Status: "WARNING", MonitorID: "5rXR3", OpenedAt: 500, Message: "description with\nnew line\nmore new line "},
-				&mkr.Host{ID: "3XYyG", Name: "app.example.com", Roles: mkr.Roles{"foo": {"bar", "baz"}}, Status: "working"},
+				&mackerel.Alert{ID: "2tZhm", Type: "check", Status: "WARNING", MonitorID: "5rXR3", OpenedAt: 500, Message: "description with\nnew line\nmore new line "},
+				&mackerel.Host{ID: "3XYyG", Name: "app.example.com", Roles: mackerel.Roles{"foo": {"bar", "baz"}}, Status: "working"},
 				nil,
 			},
 			"2tZhm 1970-01-01 00:08:20 WARNING description with... app.example.com working [foo:bar,baz]",
 		},
 		{
 			&alertSet{
-				&mkr.Alert{ID: "2tZhm", Type: "check", Status: "WARNING", MonitorID: "5rXR3", OpenedAt: 500, Message: "long long long long long long long long long long long long long long long long long long long そして長い長い alert"},
-				&mkr.Host{ID: "3XYyG", Name: "app.example.com", Roles: mkr.Roles{"foo": {"bar", "baz"}}, Status: "working"},
+				&mackerel.Alert{ID: "2tZhm", Type: "check", Status: "WARNING", MonitorID: "5rXR3", OpenedAt: 500, Message: "long long long long long long long long long long long long long long long long long long long そして長い長い alert"},
+				&mackerel.Host{ID: "3XYyG", Name: "app.example.com", Roles: mackerel.Roles{"foo": {"bar", "baz"}}, Status: "working"},
 				nil,
 			},
 			"2tZhm 1970-01-01 00:08:20 WARNING long long long long long long long long long long long long long long long long long long long そして長い... app.example.com working [foo:bar,baz]",
 		},
 		{
 			&alertSet{
-				&mkr.Alert{ID: "2tZhm", Type: "anomalyDetection", Status: "WARNING", MonitorID: "5rXR3", OpenedAt: 500},
-				&mkr.Host{ID: "3XYyG", Name: "app.example.com", Roles: mkr.Roles{"foo": {"bar", "baz"}}, Status: "working"},
-				&mkr.MonitorAnomalyDetection{ID: "5rXR3", Type: "anomalyDetection", Name: "My anomaly detection for roles", WarningSensitivity: "insensitive", MaxCheckAttempts: 5, Scopes: []string{"foo: bar", "foo: baz"}},
+				&mackerel.Alert{ID: "2tZhm", Type: "anomalyDetection", Status: "WARNING", MonitorID: "5rXR3", OpenedAt: 500},
+				&mackerel.Host{ID: "3XYyG", Name: "app.example.com", Roles: mackerel.Roles{"foo": {"bar", "baz"}}, Status: "working"},
+				&mackerel.MonitorAnomalyDetection{ID: "5rXR3", Type: "anomalyDetection", Name: "My anomaly detection for roles", WarningSensitivity: "insensitive", MaxCheckAttempts: 5, Scopes: []string{"foo: bar", "foo: baz"}},
 			},
 			"2tZhm 1970-01-01 00:08:20 WARNING My anomaly detection for roles app.example.com working [foo:bar,baz]",
 		},

--- a/annotations.go
+++ b/annotations.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	mkr "github.com/mackerelio/mackerel-client-go"
+	"github.com/mackerelio/mackerel-client-go"
 	"github.com/mackerelio/mkr/format"
 	"github.com/mackerelio/mkr/logger"
 	"github.com/mackerelio/mkr/mackerelclient"
@@ -119,7 +119,7 @@ func doAnnotationsCreate(c *cli.Context) error {
 	}
 
 	client := mackerelclient.NewFromContext(c)
-	annotation, err := client.CreateGraphAnnotation(&mkr.GraphAnnotation{
+	annotation, err := client.CreateGraphAnnotation(&mackerel.GraphAnnotation{
 		Title:       title,
 		Description: description,
 		From:        from,
@@ -189,7 +189,7 @@ func doAnnotationsUpdate(c *cli.Context) error {
 	}
 
 	client := mackerelclient.NewFromContext(c)
-	annotation, err := client.UpdateGraphAnnotation(annotationID, &mkr.GraphAnnotation{
+	annotation, err := client.UpdateGraphAnnotation(annotationID, &mackerel.GraphAnnotation{
 		Title:       title,
 		Description: description,
 		From:        from,

--- a/commands.go
+++ b/commands.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/Songmu/prompter"
-	mkr "github.com/mackerelio/mackerel-client-go"
+	"github.com/mackerelio/mackerel-client-go"
 	"github.com/mackerelio/mkr/checks"
 	"github.com/mackerelio/mkr/format"
 	"github.com/mackerelio/mkr/hosts"
@@ -214,7 +214,7 @@ func doUpdate(c *cli.Context) error {
 			} else {
 				displayname = optDisplayName
 			}
-			param := &mkr.UpdateHostParam{
+			param := &mackerel.UpdateHostParam{
 				Name:        name,
 				DisplayName: displayname,
 				Meta:        host.Meta,
@@ -282,7 +282,7 @@ func doFetch(c *cli.Context) error {
 		os.Exit(1)
 	}
 
-	allMetricValues := make(mkr.LatestMetricValues)
+	allMetricValues := make(mackerel.LatestMetricValues)
 	// Fetches 100 hosts per one request (to avoid URL maximum length).
 	for _, hostIds := range split(argHostIDs, 100) {
 		metricValues, err := mackerelclient.NewFromContext(c).FetchLatestMetricValues(hostIds, optMetricNames)

--- a/dashboards.go
+++ b/dashboards.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	mackerel "github.com/mackerelio/mackerel-client-go"
+	"github.com/mackerelio/mackerel-client-go"
 	"github.com/mackerelio/mkr/logger"
 	"github.com/mackerelio/mkr/mackerelclient"
 	"github.com/urfave/cli"

--- a/hosts/app.go
+++ b/hosts/app.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"text/template"
 
-	mackerel "github.com/mackerelio/mackerel-client-go"
+	"github.com/mackerelio/mackerel-client-go"
 
 	"github.com/mackerelio/mkr/format"
 	"github.com/mackerelio/mkr/mackerelclient"

--- a/hosts/app_test.go
+++ b/hosts/app_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	mackerel "github.com/mackerelio/mackerel-client-go"
+	"github.com/mackerelio/mackerel-client-go"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/mackerelio/mkr/mackerelclient"

--- a/mackerelclient/client.go
+++ b/mackerelclient/client.go
@@ -1,6 +1,6 @@
 package mackerelclient
 
-import mackerel "github.com/mackerelio/mackerel-client-go"
+import "github.com/mackerelio/mackerel-client-go"
 
 // Client represents a client of Mackerel API
 type Client interface {

--- a/mackerelclient/mock_client.go
+++ b/mackerelclient/mock_client.go
@@ -1,6 +1,6 @@
 package mackerelclient
 
-import mackerel "github.com/mackerelio/mackerel-client-go"
+import "github.com/mackerelio/mackerel-client-go"
 
 // MockClient represents a mock client of Mackerel API
 type MockClient struct {

--- a/mackerelclient/new.go
+++ b/mackerelclient/new.go
@@ -7,7 +7,7 @@ import (
 	"github.com/urfave/cli"
 
 	"github.com/mackerelio/mackerel-agent/config"
-	mackerel "github.com/mackerelio/mackerel-client-go"
+	"github.com/mackerelio/mackerel-client-go"
 
 	"github.com/mackerelio/mkr/logger"
 )

--- a/monitors_test.go
+++ b/monitors_test.go
@@ -4,12 +4,12 @@ import (
 	"io/ioutil"
 	"testing"
 
-	mkr "github.com/mackerelio/mackerel-client-go"
+	"github.com/mackerelio/mackerel-client-go"
 )
 
 func TestIsSameMonitor(t *testing.T) {
-	a := &mkr.MonitorConnectivity{ID: "12345", Name: "foo", Type: "connectivity"}
-	b := &mkr.MonitorConnectivity{Name: "foo", Type: "connectivity"}
+	a := &mackerel.MonitorConnectivity{ID: "12345", Name: "foo", Type: "connectivity"}
+	b := &mackerel.MonitorConnectivity{Name: "foo", Type: "connectivity"}
 
 	_, ret := isSameMonitor(a, b, true)
 	if ret != true {
@@ -24,27 +24,27 @@ func TestIsSameMonitor(t *testing.T) {
 
 func TestValidateRoles(t *testing.T) {
 	{
-		a := &mkr.MonitorConnectivity{ID: "12345", Name: "foo", Type: "connectivity"}
+		a := &mackerel.MonitorConnectivity{ID: "12345", Name: "foo", Type: "connectivity"}
 
-		ret, err := validateRules([](mkr.Monitor){a}, "test monitor")
+		ret, err := validateRules([](mackerel.Monitor){a}, "test monitor")
 		if ret != true {
 			t.Errorf("should validate the rule: %s", err.Error())
 		}
 	}
 
 	{
-		a := &mkr.MonitorAnomalyDetection{ID: "12345", Name: "anomaly", Type: "anomalyDetection", WarningSensitivity: "sensitive", Scopes: []string{"MyService: MyRole"}}
+		a := &mackerel.MonitorAnomalyDetection{ID: "12345", Name: "anomaly", Type: "anomalyDetection", WarningSensitivity: "sensitive", Scopes: []string{"MyService: MyRole"}}
 
-		ret, err := validateRules([](mkr.Monitor){a}, "anomaly detection monitor")
+		ret, err := validateRules([](mackerel.Monitor){a}, "anomaly detection monitor")
 		if ret != true {
 			t.Errorf("should validate the rule: %s", err.Error())
 		}
 	}
 
 	{
-		a := &mkr.MonitorAnomalyDetection{ID: "12345", Name: "anomaly", Type: "anomalyDetection", WarningSensitivity: "sensitive"}
+		a := &mackerel.MonitorAnomalyDetection{ID: "12345", Name: "anomaly", Type: "anomalyDetection", WarningSensitivity: "sensitive"}
 
-		ret, err := validateRules([](mkr.Monitor){a}, "anomaly detection monitor")
+		ret, err := validateRules([](mackerel.Monitor){a}, "anomaly detection monitor")
 		if ret == true || err == nil {
 			t.Error("should invalidate the rule")
 		}
@@ -69,8 +69,8 @@ func TestDiffMonitors(t *testing.T) {
    "type": "external",
    "url": "http://example.com"
  },`
-	a := &mkr.MonitorExternalHTTP{ID: "12345", Name: "foo", Type: "external", URL: "http://example.com", Service: "bar", ResponseTimeCritical: pfloat64(1000), Headers: []mkr.HeaderField{}}
-	b := &mkr.MonitorExternalHTTP{ID: "12345", Name: "foo", Type: "external", URL: "http://example.com", Service: "bar", Headers: []mkr.HeaderField{}}
+	a := &mackerel.MonitorExternalHTTP{ID: "12345", Name: "foo", Type: "external", URL: "http://example.com", Service: "bar", ResponseTimeCritical: pfloat64(1000), Headers: []mackerel.HeaderField{}}
+	b := &mackerel.MonitorExternalHTTP{ID: "12345", Name: "foo", Type: "external", URL: "http://example.com", Service: "bar", Headers: []mackerel.HeaderField{}}
 	if got := diffMonitor(a, b); got != want {
 		t.Errorf("diffMonitor: got\n%s\nwant \n%s", got, want)
 	}
@@ -81,16 +81,16 @@ func TestMonitorSaveRules(t *testing.T) {
 	if err != nil {
 		t.Errorf("should not raise error: %v", err)
 	}
-	a := &mkr.MonitorExternalHTTP{
+	a := &mackerel.MonitorExternalHTTP{
 		ID:                   "12345",
 		Name:                 "foo",
 		Type:                 "external",
 		URL:                  "http://example.com",
 		Service:              "bar",
 		ResponseTimeCritical: pfloat64(1000),
-		Headers:              []mkr.HeaderField{},
+		Headers:              []mackerel.HeaderField{},
 	}
-	monitorSaveRules([]mkr.Monitor{a}, tmpFile.Name())
+	monitorSaveRules([]mackerel.Monitor{a}, tmpFile.Name())
 
 	byt, _ := ioutil.ReadFile(tmpFile.Name())
 	content := string(byt)
@@ -114,7 +114,7 @@ func TestMonitorSaveRules(t *testing.T) {
 }
 
 func TestStringifyMonitor(t *testing.T) {
-	a := &mkr.MonitorConnectivity{ID: "12345", Name: "foo", Type: "connectivity"}
+	a := &mackerel.MonitorConnectivity{ID: "12345", Name: "foo", Type: "connectivity"}
 	expected := `+{
 +  "id": "12345",
 +  "name": "foo",
@@ -128,12 +128,12 @@ func TestStringifyMonitor(t *testing.T) {
 }
 
 func TestDiffMonitorsWithScopes(t *testing.T) {
-	a := &mkr.MonitorConnectivity{
+	a := &mackerel.MonitorConnectivity{
 		ID:   "12345",
 		Name: "foo",
 		Type: "connectivity",
 	}
-	b := &mkr.MonitorConnectivity{
+	b := &mackerel.MonitorConnectivity{
 		ID:     "12345",
 		Name:   "foo",
 		Type:   "connectivity",
@@ -163,7 +163,7 @@ func TestDiffMonitorsWithScopes(t *testing.T) {
 		t.Errorf("expected:\n%s\n, output:\n%s\n", expected, diff)
 	}
 
-	c := &mkr.MonitorConnectivity{
+	c := &mackerel.MonitorConnectivity{
 		ID:     "12345",
 		Name:   "foo",
 		Type:   "connectivity",
@@ -183,7 +183,7 @@ func TestDiffMonitorsWithScopes(t *testing.T) {
 		t.Errorf("expected:\n%s\n, output:\n%s\n", expected, diff)
 	}
 
-	d := &mkr.MonitorConnectivity{
+	d := &mackerel.MonitorConnectivity{
 		ID:     "12345",
 		Name:   "foo",
 		Type:   "connectivity",

--- a/org/app_test.go
+++ b/org/app_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	mackerel "github.com/mackerelio/mackerel-client-go"
+	"github.com/mackerelio/mackerel-client-go"
 
 	"github.com/mackerelio/mkr/mackerelclient"
 )

--- a/services/app_test.go
+++ b/services/app_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	mackerel "github.com/mackerelio/mackerel-client-go"
+	"github.com/mackerelio/mackerel-client-go"
 
 	"github.com/mackerelio/mkr/mackerelclient"
 )

--- a/throw.go
+++ b/throw.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/jpillora/backoff"
-	mkr "github.com/mackerelio/mackerel-client-go"
+	"github.com/mackerelio/mackerel-client-go"
 	"github.com/mackerelio/mkr/logger"
 	"github.com/mackerelio/mkr/mackerelclient"
 	"github.com/urfave/cli"
@@ -38,7 +38,7 @@ func doThrow(c *cli.Context) error {
 	optService := c.String("service")
 	optMaxRetry := c.Int("retry")
 
-	var metricValues []*(mkr.MetricValue)
+	var metricValues []*(mackerel.MetricValue)
 
 	scanner := bufio.NewScanner(os.Stdin)
 	for scanner.Scan() {
@@ -66,7 +66,7 @@ func doThrow(c *cli.Context) error {
 			name = "custom." + name
 		}
 
-		metricValue := &mkr.MetricValue{
+		metricValue := &mackerel.MetricValue{
 			Name:  name,
 			Value: value,
 			Time:  time,
@@ -120,7 +120,7 @@ func requestWithRetry(f func() error, maxRetry int) error {
 		if err = f(); err == nil {
 			// SUCCESS!!
 			break
-		} else if e, isAPIError := err.(*mkr.APIError); isAPIError {
+		} else if e, isAPIError := err.(*mackerel.APIError); isAPIError {
 			// Do not retry when status is 4XX
 			if e.StatusCode >= 400 && e.StatusCode < 500 {
 				break

--- a/throw_test.go
+++ b/throw_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	mkr "github.com/mackerelio/mackerel-client-go"
+	"github.com/mackerelio/mackerel-client-go"
 )
 
 func init() {
@@ -121,7 +121,7 @@ func TestRequestWithRetry_Status(t *testing.T) {
 	var status int
 	f0 := func() error {
 		counter++
-		return &mkr.APIError{StatusCode: status, Message: "ohno"}
+		return &mackerel.APIError{StatusCode: status, Message: "ohno"}
 	}
 
 	counter = 0

--- a/wrap/wrap.go
+++ b/wrap/wrap.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/Songmu/retry"
 	"github.com/Songmu/wrapcommander"
-	mackerel "github.com/mackerelio/mackerel-client-go"
+	"github.com/mackerelio/mackerel-client-go"
 	"github.com/mackerelio/mkr/logger"
 	"github.com/urfave/cli"
 	"golang.org/x/sync/errgroup"

--- a/wrap/wrap_test.go
+++ b/wrap/wrap_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	mackerel "github.com/mackerelio/mackerel-client-go"
+	"github.com/mackerelio/mackerel-client-go"
 	"github.com/urfave/cli"
 )
 


### PR DESCRIPTION
closes: https://github.com/mackerelio/mkr/issues/261

## Changes I've made

- Stop using the `mkr` alias and use the package name `mackerel` instead
- Stop using the `mackerel` alias since it has no meaning

I think I've covered all the imports:
```sh
$ git grep "mackerel-client-go" -- "*.go"
alerts.go:      "github.com/mackerelio/mackerel-client-go"
alerts_test.go: "github.com/mackerelio/mackerel-client-go"
annotations.go: "github.com/mackerelio/mackerel-client-go"
commands.go:    "github.com/mackerelio/mackerel-client-go"
dashboards.go:  "github.com/mackerelio/mackerel-client-go"
hosts/app.go:   "github.com/mackerelio/mackerel-client-go"
hosts/app_test.go:      "github.com/mackerelio/mackerel-client-go"
mackerelclient/client.go:import "github.com/mackerelio/mackerel-client-go"
mackerelclient/mock_client.go:import "github.com/mackerelio/mackerel-client-go"
mackerelclient/new.go:  "github.com/mackerelio/mackerel-client-go"
monitors.go:    "github.com/mackerelio/mackerel-client-go"
monitors.go:// There are almost same code in mackerel-client-go.
monitors.go:// There are almost same code in mackerel-client-go.
monitors_test.go:       "github.com/mackerelio/mackerel-client-go"
org/app_test.go:        "github.com/mackerelio/mackerel-client-go"
services/app_test.go:   "github.com/mackerelio/mackerel-client-go"
throw.go:       "github.com/mackerelio/mackerel-client-go"
throw_test.go:  "github.com/mackerelio/mackerel-client-go"
wrap/wrap.go:   "github.com/mackerelio/mackerel-client-go"
wrap/wrap_test.go:      "github.com/mackerelio/mackerel-client-go"
```