### PR TITLE
show mandantory flags usage in modern CLI manner

### DIFF
--- a/annotations.go
+++ b/annotations.go
@@ -21,7 +21,7 @@ var commandAnnotations = cli.Command{
 		{
 			Name:      "create",
 			Usage:     "create a graph annotation",
-			ArgsUsage: "[--title <title>] [--description <descriptio>] [--from <from>] [--to <to>] [--service -s <service>] [--role -r <role>]",
+			ArgsUsage: "--title <title> [--description <descriptio>] --from <from> --to <to> --service -s <service> [--role -r <role>]",
 			Description: `
     Creates a graph annotation.
 `,
@@ -42,7 +42,7 @@ var commandAnnotations = cli.Command{
 		{
 			Name:      "list",
 			Usage:     "list annotations",
-			ArgsUsage: "[--from <from>] [--to <to>] [--service -s <service>]",
+			ArgsUsage: "--from <from> --to <to> --service -s <service>",
 			Description: `
     Shows annotations by service name and duration (from and to)
 `,
@@ -56,7 +56,7 @@ var commandAnnotations = cli.Command{
 		{
 			Name:      "update",
 			Usage:     "update annotation",
-			ArgsUsage: "[--id <id>] [--title <title>] [--description <descriptio>] [--from <from>] [--to <to>] [--service -s <service>] [--role -r <role>]",
+			ArgsUsage: "--id <id> [--title <title>] [--description <descriptio>] --from <from> --to <to> --service -s <service> [--role -r <role>]",
 			Description: `
     Updates an annotation
 `,
@@ -78,7 +78,7 @@ var commandAnnotations = cli.Command{
 		{
 			Name:      "delete",
 			Usage:     "delete annotation",
-			ArgsUsage: "[--id <id>]",
+			ArgsUsage: "--id <id>",
 			Description: `
     Delete graph annotation by annotation id
 `,

--- a/annotations.go
+++ b/annotations.go
@@ -21,7 +21,7 @@ var commandAnnotations = cli.Command{
 		{
 			Name:      "create",
 			Usage:     "create a graph annotation",
-			ArgsUsage: "--title <title> [--description <descriptio>] --from <from> --to <to> --service -s <service> [--role -r <role>]",
+			ArgsUsage: "--title <title> [--description <descriptio>] --from <from> --to <to> --service|-s <service> [--role|-r <role>]",
 			Description: `
     Creates a graph annotation.
 `,
@@ -42,7 +42,7 @@ var commandAnnotations = cli.Command{
 		{
 			Name:      "list",
 			Usage:     "list annotations",
-			ArgsUsage: "--from <from> --to <to> --service -s <service>",
+			ArgsUsage: "--from <from> --to <to> --service|-s <service>",
 			Description: `
     Shows annotations by service name and duration (from and to)
 `,
@@ -56,7 +56,7 @@ var commandAnnotations = cli.Command{
 		{
 			Name:      "update",
 			Usage:     "update annotation",
-			ArgsUsage: "--id <id> [--title <title>] [--description <descriptio>] --from <from> --to <to> --service -s <service> [--role -r <role>]",
+			ArgsUsage: "--id <id> [--title <title>] [--description <descriptio>] --from <from> --to <to> --service|-s <service> [--role|-r <role>]",
 			Description: `
     Updates an annotation
 `,


### PR DESCRIPTION
fix #272 

I searched CLI usage code with `git grep '\[-' **/*.go` and manually checked flags validation code.

----

One more thing: It will be found that no validation in Go but done by server-side and not found above `git-grep`.