### PR TITLE
Stop building 32bit Darwin artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,9 @@ gofmt: test-deps
 
 .PHONY: cross
 cross: devel-deps
-	goxz -d snapshot -os darwin,linux -arch 386,amd64 \
+	goxz -d snapshot -os darwin -arch amd64 \
+	  -build-ldflags=$(BUILD_LDFLAGS)
+	goxz -d snapshot -os linux -arch 386,amd64 \
 	  -build-ldflags=$(BUILD_LDFLAGS)
 
 .PHONY: rpm


### PR DESCRIPTION
32bit Darwin is an ancient one, so remove from crossbuild targets.
ref: https://github.com/mackerelio/mackerel-agent/pull/600
(note: Go 1.14 is the last Go release to support 32-bit binaries on macOS: https://golang.org/doc/go1.14)