### PR TITLE
define default file name while doMonitorsPull() at once

### DIFF
--- a/monitors.go
+++ b/monitors.go
@@ -71,11 +71,7 @@ var commandMonitors = cli.Command{
 	},
 }
 
-func monitorSaveRules(rules []mackerel.Monitor, optFilePath string) error {
-	filePath := "monitors.json"
-	if optFilePath != "" {
-		filePath = optFilePath
-	}
+func monitorSaveRules(rules []mackerel.Monitor, filePath string) error {
 	file, err := os.Create(filePath)
 	if err != nil {
 		log.Fatal(err)
@@ -172,15 +168,15 @@ func doMonitorsPull(c *cli.Context) error {
 	monitors, err := mackerelclient.NewFromContext(c).FindMonitors()
 	logger.DieIf(err)
 
+	if filePath == "" {
+		filePath = "monitors.json"
+	}
 	monitorSaveRules(monitors, filePath)
 
 	if isVerbose {
 		format.PrettyPrintJSON(os.Stdout, monitors)
 	}
 
-	if filePath == "" {
-		filePath = "monitors.json"
-	}
 	logger.Log("info", fmt.Sprintf("Monitor rules are saved to '%s' (%d rules).", filePath, len(monitors)))
 	return nil
 }


### PR DESCRIPTION
At doMonitorsPull(), the default file name "monitors.json" are defined twice. However, it is supposed to be enough at once.

doMonitorsPull() のなかで、 monitors.json を `monitorSaveRules()` でのファイル保存時と、 ログ出力時で、別々にoptを解決していますが、一箇所で十分になるのではと思い、動作には変わりはありませんが、PR出させていただきました。

Operation Check Result

```
-> % ./mkr monitors pull
      info Monitor rules are saved to 'monitors.json' (14 rules).
kazukihigashiguchi@BASE-P0126-MBP [19時09分06秒] [~/go/src/github.com/hgsgtk/mkr] [refactor/filepath *]
-> % ./mkr monitors pull --file-path=hoge.json
      info Monitor rules are saved to 'hoge.json' (14 rules).
```