### PR TITLE
revert changing filename

### DIFF
--- a/packaging/deb/debian/control
+++ b/packaging/deb/debian/control
@@ -7,5 +7,5 @@ Standards-Version: 3.9.4
 Homepage: https://mackerel.io
 
 Package: mkr
-Architecture: any
+Architecture: all
 Description: macekrel.io api client tool


### PR DESCRIPTION
I've introduced `Architecture: any` at #310 but its side-effects was changing package filename unexpectedly.
So I revert that changes.