### PR TITLE
Add armhf Debian package to GitHub release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 - >-
   DEBIAN_FRONTEND=noninteractive
   sudo apt-get install -y
-  rpm devscripts debhelper fakeroot crossbuild-essential-arm64
+  rpm devscripts debhelper fakeroot crossbuild-essential-arm64 crossbuild-essential-armhf
 - mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
 script:
 - make all

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ gofmt: test-deps
 cross: devel-deps
 	goxz -d snapshot -os darwin -arch amd64 \
 	  -build-ldflags=$(BUILD_LDFLAGS)
-	goxz -d snapshot -os linux -arch 386,amd64,arm64 \
+	goxz -d snapshot -os linux -arch 386,amd64,arm64,arm \
 	  -build-ldflags=$(BUILD_LDFLAGS)
 
 .PHONY: rpm
@@ -57,7 +57,7 @@ rpm-v1:
 	rpmbuild --define "_builddir `pwd`" --define "_version ${VERSION}" --define "buildarch x86_64" --target x86_64  -bb packaging/rpm/mkr.spec
 
 .PHONY: rpm-v2
-rpm-v2: rpm-v2-x86 rpm-v2-arm
+rpm-v2: rpm-v2-x86 rpm-v2-arm64
 
 .PHONY: rpm-v2-x86
 rpm-v2-x86:
@@ -69,8 +69,8 @@ rpm-v2-x86:
 	  --define "buildarch x86_64" --target x86_64 --define "dist .amzn2" \
 	  -bb packaging/rpm/mkr-v2.spec
 
-.PHONY: rpm-v2-arm
-rpm-v2-arm:
+.PHONY: rpm-v2-arm64
+rpm-v2-arm64:
 	GOOS=linux GOARCH=arm64 make build
 	rpmbuild --define "_builddir `pwd`" --define "_version ${VERSION}" \
 	  --define "buildarch aarch64" --target aarch64 --define "dist .el7.centos" \
@@ -89,7 +89,7 @@ deb-v1:
 	cd packaging/deb && debuild --no-tgz-check -rfakeroot -uc -us
 
 .PHONY: deb-v2
-deb-v2: deb-v2-x86 deb-v2-arm
+deb-v2: deb-v2-x86 deb-v2-arm64 deb-v2-arm
 
 .PHONY: deb-v2-x86
 deb-v2-x86:
@@ -97,11 +97,17 @@ deb-v2-x86:
 	cp $(BIN) packaging/deb-v2/debian/$(BIN).bin
 	cd packaging/deb-v2 && debuild --no-tgz-check -rfakeroot -uc -us
 
-.PHONY: deb-v2-arm
-deb-v2-arm:
+.PHONY: deb-v2-arm64
+deb-v2-arm64:
 	GOOS=linux GOARCH=arm64 make build
 	cp $(BIN) packaging/deb-v2/debian/$(BIN).bin
 	cd packaging/deb-v2 && debuild --no-tgz-check -rfakeroot -uc -us -aarm64
+
+.PHONY: deb-v2-arm
+deb-v2-arm:
+	GOOS=linux GOARCH=arm ARM=6 make build # Build ARMv6 binary for Raspbian
+	cp $(BIN) packaging/deb-v2/debian/$(BIN).bin
+	cd packaging/deb-v2 && debuild --no-tgz-check -rfakeroot -uc -us -aarmhf
 
 .PHONY: check-release-deps
 check-release-deps:


### PR DESCRIPTION
Add armhf(32bit ARM with hardfloat) Debian/Raspberry Pi OS package support.

The package has already been tested on my own Raspberry Pi Zero, and it works fine.