### PR TITLE
Print empty array if hosts not found

### DIFF
--- a/hosts/app.go
+++ b/hosts/app.go
@@ -54,7 +54,7 @@ func (ha *hostApp) findHosts(param findHostsParam) error {
 	case param.verbose:
 		return format.PrettyPrintJSON(ha.outStream, hosts)
 	default:
-		var hostsFormat []*format.Host
+		hostsFormat := make([]*format.Host, 0)
 		for _, host := range hosts {
 			hostsFormat = append(hostsFormat, &format.Host{
 				ID:            host.ID,

--- a/hosts/app_test.go
+++ b/hosts/app_test.go
@@ -163,25 +163,25 @@ bar sample.app2 standby 1552000000
 			id:       "name",
 			hosts:    []*mackerel.Host{},
 			name:     "Sample.app",
-			expected: "null\n",
+			expected: "[]\n",
 		},
 		{
 			id:       "service",
 			hosts:    []*mackerel.Host{},
 			service:  "SampleService",
-			expected: "null\n",
+			expected: "[]\n",
 		},
 		{
 			id:       "roles",
 			hosts:    []*mackerel.Host{},
 			roles:    []string{"role1", "role2"},
-			expected: "null\n",
+			expected: "[]\n",
 		},
 		{
 			id:       "statuses",
 			hosts:    []*mackerel.Host{},
 			statuses: []string{mackerel.HostStatusPoweroff, mackerel.HostStatusMaintenance},
-			expected: "null\n",
+			expected: "[]\n",
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
related: https://github.com/mackerelio/mkr/issues/324

initialize hostsFormat with make to avoid print "null" when no hosts found.
