### PR TITLE
fix condition to delete monitors

### DIFF
--- a/monitors.go
+++ b/monitors.go
@@ -358,7 +358,7 @@ func checkMonitorsDiff(c *cli.Context) monitorDiff {
 				break
 			}
 		}
-		if found {
+		if !found {
 			monitorDiff.onlyRemote = append(monitorDiff.onlyRemote, remote)
 		}
 	}


### PR DESCRIPTION
This bug introduced #348 , and released it since 2021-02-16 05:53 UTC.

effects: `mkr monitors {diff|push}`