### PR TITLE
Replacing the version update process

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,0 +1,42 @@
+name: 'Create Release PR'
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'next release version'
+        required: true
+env:
+  GIT_AUTHOR_NAME: mackerelbot
+  GIT_AUTHOR_EMAIL: mackerelbot@users.noreply.github.com
+  GIT_COMMITTER_NAME: mackerelbot
+  GIT_COMMITTER_EMAIL: mackerelbot@users.noreply.github.com
+
+jobs:
+  create:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: mackerelio/mackerel-create-release-pull-request-action@main
+        id: start
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          next_version: ${{ github.event.inputs.release_version }}
+          package_name: mkr
+
+      - run: |
+          CURRENT=${{ steps.start.outputs.currentVersion }}
+          NEXT=${{ steps.start.outputs.nextVersion }}
+          mv packaging/mkr_$CURRENT.orig.tar.gz packaging/mkr_$NEXT.orig.tar.gz
+
+      - uses: mackerelio/mackerel-create-release-pull-request-action@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          finished: "true"
+          package_name: mkr
+          next_version: ${{ steps.start.outputs.nextVersion }}
+          branch_name: ${{ steps.start.outputs.branchName }}
+          pull_request_infos: ${{ steps.start.outputs.pullRequestInfos }}
+        # TODO: remove below lines. when completed test.
+        env:
+          RUNNER_DEBUG: 1


### PR DESCRIPTION
We are using Mackerel::ReleaseUtils in the version update process and want to replace it.
In this pull request, I'm writing the code to try the replacement.

This GitHub Action does not actually work, but runs in "dry-run" mode.

