### PR TITLE
added compile option, fix packaging format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: ['ubuntu-18.04', 'macOS-10.15', 'windows-2019']
+        os: ['ubuntu-latest', 'macOS-10.15', 'windows-2019']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test:
 
 .PHONY: build
 build:
-	go build -ldflags=$(BUILD_LDFLAGS) -o $(BIN) .
+	CGO_ENABLED=0 go build -ldflags=$(BUILD_LDFLAGS) -o $(BIN) .
 
 .PHONY: cross
 cross: devel-deps

--- a/packaging/deb-v2/debian/rules
+++ b/packaging/deb-v2/debian/rules
@@ -6,6 +6,9 @@
 
 package=mkr
 
+override_dh_builddeb:
+	dh_builddeb -- -Zxz
+
 override_dh_auto_install:
 	dh_auto_install
 	install -d -m 755 debian/${package}/usr/bin/

--- a/packaging/deb/debian/rules
+++ b/packaging/deb/debian/rules
@@ -6,6 +6,9 @@
 
 package=mkr
 
+override_dh_builddeb:
+	dh_builddeb -- -Zxz
+
 override_dh_auto_install:
 	dh_auto_install
 	install -d -m 755 debian/${package}/usr/local/bin/


### PR DESCRIPTION
Changed to use xz format for compressing debian packages. refer https://github.com/mackerelio/mackerel-agent-plugins/pull/981

The environment ubuntu-latest for GitHub Actions is ubuntu 22.04.
It turns out that glibc is new and the built binary compatibility is broken in some environments.
So I made a change to build with CGO_ENABLED=0