### PR TITLE
improve `mkr status -v` to show host metrics

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -22,6 +22,7 @@ type Host struct {
 	IsRetired     bool              `json:"isRetired"` // 'omitempty' regard boolean 'false' as empty.
 	CreatedAt     string            `json:"createdAt,omitempty"`
 	IPAddresses   map[string]string `json:"ipAddresses,omitempty"`
+	Metrics       []string          `json:"metrics,omitempty"`
 }
 
 // PrettyPrintJSON outputs JSON or filtered result by jq query via stdout.

--- a/format/format.go
+++ b/format/format.go
@@ -22,7 +22,6 @@ type Host struct {
 	IsRetired     bool              `json:"isRetired"` // 'omitempty' regard boolean 'false' as empty.
 	CreatedAt     string            `json:"createdAt,omitempty"`
 	IPAddresses   map[string]string `json:"ipAddresses,omitempty"`
-	Metrics       []string          `json:"metrics,omitempty"`
 }
 
 // PrettyPrintJSON outputs JSON or filtered result by jq query via stdout.

--- a/mackerelclient/client.go
+++ b/mackerelclient/client.go
@@ -12,4 +12,5 @@ type Client interface {
 	GetOrg() (*mackerel.Org, error)
 	CreateHost(param *mackerel.CreateHostParam) (string, error)
 	UpdateHostStatus(hostID string, status string) error
+	ListHostMetricNames(id string) ([]string, error)
 }

--- a/mackerelclient/mock_client.go
+++ b/mackerelclient/mock_client.go
@@ -12,6 +12,7 @@ type MockClient struct {
 	getOrgCallback              func() (*mackerel.Org, error)
 	createHostCallback          func(param *mackerel.CreateHostParam) (string, error)
 	updateHostStatusCallback    func(hostID string, status string) error
+	listHostMetricNamesCallback func(id string) ([]string, error)
 }
 
 // MockClientOption represents an option of mock client of Mackerel API
@@ -154,5 +155,20 @@ func (c *MockClient) FindAWSIntegrations() ([]*mackerel.AWSIntegration, error) {
 func MockFindAWSIntegrations(callback func() ([]*mackerel.AWSIntegration, error)) MockClientOption {
 	return func(c *MockClient) {
 		c.findAWSIntegrationsCallback = callback
+	}
+}
+
+// ListHostMetricNames ...
+func (c *MockClient) ListHostMetricNames(hostID string) ([]string, error) {
+	if c.listHostMetricNamesCallback != nil {
+		return c.listHostMetricNamesCallback(hostID)
+	}
+	return nil, errCallbackNotFound("ListHostMetricNames")
+}
+
+// MockListHostMetricNames returns an option to set the callback of ListHostMetricNames
+func MockListHostMetricNames(callback func(string) ([]string, error)) MockClientOption {
+	return func(c *MockClient) {
+		c.listHostMetricNamesCallback = callback
 	}
 }

--- a/status/app.go
+++ b/status/app.go
@@ -3,6 +3,8 @@ package status
 import (
 	"io"
 
+	"github.com/mackerelio/mackerel-client-go"
+
 	"github.com/mackerelio/mkr/format"
 	"github.com/mackerelio/mkr/logger"
 	"github.com/mackerelio/mkr/mackerelclient"
@@ -17,6 +19,11 @@ type statussApp struct {
 	jqFilter  string
 }
 
+type HostWithMetrics struct {
+	*mackerel.Host
+	Metrics []string `json:"metrics,omitempty"`
+}
+
 func (app *statussApp) run() error {
 	host, err := app.client.FindHost(app.argHostID)
 	if err != nil {
@@ -24,9 +31,10 @@ func (app *statussApp) run() error {
 	}
 
 	if app.isVerbose {
-		metrics, _ := app.client.ListHostMetricNames(host.ID)
-		host.Metrics = metrics
-		err := format.PrettyPrintJSON(app.outStream, host, app.jqFilter)
+		metrics, err := app.client.ListHostMetricNames(host.ID)
+		logger.DieIf(err)
+		hostWithMetrics := HostWithMetrics{Host: host, Metrics: metrics}
+		err = format.PrettyPrintJSON(app.outStream, hostWithMetrics, app.jqFilter)
 		logger.DieIf(err)
 	} else {
 		err := format.PrettyPrintJSON(app.outStream, &format.Host{

--- a/status/app.go
+++ b/status/app.go
@@ -24,6 +24,8 @@ func (app *statussApp) run() error {
 	}
 
 	if app.isVerbose {
+		metrics, _ := app.client.ListHostMetricNames(host.ID)
+		host.Metrics = metrics
 		err := format.PrettyPrintJSON(app.outStream, host, app.jqFilter)
 		logger.DieIf(err)
 	} else {


### PR DESCRIPTION
This patch adds to mkr the ability to output a list of host-metrics that the host has.
The output of the metric list will only work with `mkr status -v` (verbose mode), so there will be no performance impact in general use.

```
$ mkr status 4Hkc5RWzUQG
{
    "id": "4Hkc5RWzUQG",
  ...
    "ipAddresses": {
 ...
    }
}

$ mkr status -v 4Hkc5RWzUQG
{
    "id": "4Hkc5RWzUQG",
  ...
    "interfaces": [
 ...
    ],
    "metrics": [
        "cpu.guest.percentage",
 ...
        "memory.used"
    ]
}
```