### PR TITLE
Enables Dependabot version updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,22 @@
 version: 2
 updates:
-- package-ecosystem: docker
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "01:00"
-    timezone: Asia/Tokyo
-  open-pull-requests-limit: 10
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "01:00"
-    timezone: Asia/Tokyo
-  open-pull-requests-limit: 10
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "01:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 10
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "01:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 10
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "01:00"
+      timezone: Asia/Tokyo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: Build
 on:
   push:
     branches:
-    - master
+      - master
     tags:
-    - v*
+      - v*
   pull_request:
 env:
   DEBIAN_FRONTEND: noninteractive
@@ -13,117 +13,117 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
-      with:
-        go-version-file: go.mod
-    - uses: golangci/golangci-lint-action@v3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+      - uses: golangci/golangci-lint-action@v3
   test:
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macOS-10.15', 'windows-2019']
+        os: ["ubuntu-latest", "macOS-10.15", "windows-2019"]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - uses: actions/setup-go@v3
-      with:
-        go-version: 1.19.x
-    - run: |
-        go test -race -covermode atomic -coverprofile=profile.cov ./...
-      shell: bash
-    - uses: shogo82148/actions-goveralls@v1
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-profile: profile.cov
-        parallel: true
-        flag-name: Go-${{ matrix.os }}
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19.x
+      - run: |
+          go test -race -covermode atomic -coverprofile=profile.cov ./...
+        shell: bash
+      - uses: shogo82148/actions-goveralls@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-profile: profile.cov
+          parallel: true
+          flag-name: Go-${{ matrix.os }}
   finish:
     needs: test
     runs-on: ubuntu-latest
     steps:
-    - uses: shogo82148/actions-goveralls@v1
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        parallel-finished: true
+      - uses: shogo82148/actions-goveralls@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true
   build:
     needs: [lint, test]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
     steps:
-    - run: |
-        sudo apt-get update
-        sudo apt-get install -y \
-          rpm devscripts debhelper fakeroot \
-          crossbuild-essential-arm64 crossbuild-essential-armhf
-        mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
-    - uses: actions/cache@v2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - uses: actions/setup-go@v3
-      with:
-        go-version: 1.19.x
-    - uses: actions/checkout@v2
-    - run: make all
-    - uses: actions/upload-artifact@v2
-      with:
-        name: linux-build-artifacts
-        path: |
-          ~/rpmbuild/RPMS/*/*.rpm
-          packaging/*.deb
-          snapshot/*.zip
-          snapshot/*.tar.gz
-          build/*.tar.gz
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            rpm devscripts debhelper fakeroot \
+            crossbuild-essential-arm64 crossbuild-essential-armhf
+          mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19.x
+      - uses: actions/checkout@v2
+      - run: make all
+      - uses: actions/upload-artifact@v2
+        with:
+          name: linux-build-artifacts
+          path: |
+            ~/rpmbuild/RPMS/*/*.rpm
+            packaging/*.deb
+            snapshot/*.zip
+            snapshot/*.tar.gz
+            build/*.tar.gz
 
   release:
     needs: build
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
     steps:
-    - uses: actions/download-artifact@v2
-      with:
-        name: linux-build-artifacts
-        path: artifacts/
+      - uses: actions/download-artifact@v2
+        with:
+          name: linux-build-artifacts
+          path: artifacts/
 
-    - uses: mackerelio/staging-release-update-action@main
-      if: github.ref == 'refs/heads/master'
-      with:
-        directory: artifacts/
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        tag: staging
+      - uses: mackerelio/staging-release-update-action@main
+        if: github.ref == 'refs/heads/master'
+        with:
+          directory: artifacts/
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          tag: staging
 
-    - uses: mackerelio/create-release-action@main
-      if: startsWith(github.ref, 'refs/tags/v')
-      with:
-        directory: artifacts/
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        tag-prefix: 'refs/tags/v'
-        bump-up-branch-prefix: 'bump-version-'
+      - uses: mackerelio/create-release-action@main
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          directory: artifacts/
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          tag-prefix: "refs/tags/v"
+          bump-up-branch-prefix: "bump-version-"
 
-    - name: update homebrew-mackerel-agent
-      if: startsWith(github.ref, 'refs/tags/v')
-      uses: peter-evans/repository-dispatch@v1
-      with:
-        token: ${{ secrets.MACKERELBOT_GITHUB_TOKEN }}
-        event-type: release
-        client-payload: '{"product": "mkr"}'
-        repository: mackerelio/homebrew-mackerel-agent
+      - name: update homebrew-mackerel-agent
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.MACKERELBOT_GITHUB_TOKEN }}
+          event-type: release
+          client-payload: '{"product": "mkr"}'
+          repository: mackerelio/homebrew-mackerel-agent
 
-    - uses: 8398a7/action-slack@v3
-      with:
-        status: ${{ job.status }}
-        fields: repo,message,commit,action,eventName,ref,workflow,job,took
-        username: mkr-release
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.MACKEREL_SLACK_WEBHOOK_URL }}
+      - uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,action,eventName,ref,workflow,job,took
+          username: mkr-release
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.MACKEREL_SLACK_WEBHOOK_URL }}
 
   build_images_and_push:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,9 +1,9 @@
-name: 'Create Release PR'
+name: "Create Release PR"
 on:
   workflow_dispatch:
     inputs:
       release_version:
-        description: 'next release version'
+        description: "next release version"
         required: true
 env:
   GIT_AUTHOR_NAME: mackerelbot
@@ -37,4 +37,3 @@ jobs:
           next_version: ${{ steps.start.outputs.nextVersion }}
           branch_name: ${{ steps.start.outputs.branchName }}
           pull_request_infos: ${{ steps.start.outputs.pullRequestInfos }}
-


### PR DESCRIPTION
This repository's workflows look antiquated. Deprecated features and runtimes of Github Actions will soon be unavailable.

So we activate dependabot for GitHub Actions to automate updates.