### PR TITLE
Add metric-names subcommand.

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mackerelio/mkr/checks"
 	"github.com/mackerelio/mkr/dashboards"
 	"github.com/mackerelio/mkr/hosts"
+	"github.com/mackerelio/mkr/metric_names"
 	"github.com/mackerelio/mkr/metrics"
 	"github.com/mackerelio/mkr/monitors"
 	"github.com/mackerelio/mkr/org"
@@ -39,4 +40,5 @@ var Commands = []cli.Command{
 	checks.Command,
 	wrap.Command,
 	aws_integrations.Command,
+	metric_names.Command,
 }

--- a/metric_names/command.go
+++ b/metric_names/command.go
@@ -17,7 +17,7 @@ var Command = cli.Command{
 	Description: `
     Fetch metric names of 'host metric' or 'service metric'.
     Requests "/api/v0/hosts/<hostId>/metric-names" or "/api/v0/services/<serviceName>/metric-names".
-    See https://mackerel.io/ja/api-docs/entry/hosts#metric-names, https://mackerel.io/ja/api-docs/entry/services#metric-names
+    See https://mackerel.io/api-docs/entry/hosts#metric-names, https://mackerel.io/api-docs/entry/services#metric-names
 `,
 	Action: doMetricNames,
 	Flags: []cli.Flag{

--- a/metric_names/command.go
+++ b/metric_names/command.go
@@ -1,0 +1,53 @@
+package metric_names
+
+import (
+	"os"
+
+	"github.com/mackerelio/mkr/format"
+	"github.com/mackerelio/mkr/jq"
+	"github.com/mackerelio/mkr/logger"
+	"github.com/mackerelio/mkr/mackerelclient"
+	"github.com/urfave/cli"
+)
+
+var Command = cli.Command{
+	Name:      "metric-names",
+	Usage:     "Fetch metric names",
+	ArgsUsage: "[--host | -H <hostId>] [--service | -s <service>] [--jq <formula>]",
+	Description: `
+    Fetch metric names of 'host metric' or 'service metric'.
+    Requests "/api/v0/hosts/<hostId>/metric-names" or "/api/v0/services/<serviceName>/metric-names".
+    See https://mackerel.io/ja/api-docs/entry/hosts#metric-names, https://mackerel.io/ja/api-docs/entry/services#metric-names
+`,
+	Action: doMetricNames,
+	Flags: []cli.Flag{
+		cli.StringFlag{Name: "host, H", Value: "", Usage: "Fetch host metric names of <hostID>."},
+		cli.StringFlag{Name: "service, s", Value: "", Usage: "Fetch service metric names of <service>."},
+		jq.CommandLineFlag,
+	},
+}
+
+func doMetricNames(c *cli.Context) error {
+	optHostID := c.String("host")
+	optService := c.String("service")
+	jq := c.String("jq")
+
+	client := mackerelclient.NewFromContext(c)
+
+	if optHostID != "" {
+		metricNames, err := client.ListHostMetricNames(optHostID)
+		logger.DieIf(err)
+
+		err = format.PrettyPrintJSON(os.Stdout, metricNames, jq)
+		logger.DieIf(err)
+	} else if optService != "" {
+		metricNames, err := client.ListServiceMetricNames(optService)
+		logger.DieIf(err)
+
+		err = format.PrettyPrintJSON(os.Stdout, metricNames, jq)
+		logger.DieIf(err)
+	} else {
+		cli.ShowCommandHelpAndExit(c, "metric-names", 1)
+	}
+	return nil
+}


### PR DESCRIPTION
Hi. I added metric-names subcommand.

metric-names fetches metric names of the host or service.

```
mkr metric-names --help
NAME:
   mkr metric-names - Fetch metric names

USAGE:
   mkr metric-names [command options] [--host | -H <hostId>] [--service | -s <service>] [--jq <formula>]

DESCRIPTION:
   
    Fetch metric names of 'host metric' or 'service metric'.
    Requests "/api/v0/hosts/<hostId>/metric-names" or "/api/v0/services/<serviceName>/metric-names".
    See https://mackerel.io/ja/api-docs/entry/hosts#metric-names, https://mackerel.io/ja/api-docs/entry/services#metric-names


OPTIONS:
   --host value, -H value     Fetch host metric names of <hostID>.
   --service value, -s value  Fetch service metric names of <service>.
   --jq value                 Filter response values using jq syntax
```