### PR TITLE
read annotation's description from file or stdin

### DIFF
--- a/annotations/command.go
+++ b/annotations/command.go
@@ -1,6 +1,7 @@
 package annotations
 
 import (
+	"io"
 	"os"
 
 	"github.com/mackerelio/mackerel-client-go"
@@ -30,6 +31,7 @@ var Command = cli.Command{
 			Flags: []cli.Flag{
 				cli.StringFlag{Name: "title", Usage: "Title for annotation"},
 				cli.StringFlag{Name: "description", Usage: "Description for annotation"},
+				cli.StringFlag{Name: "description-file", Usage: `Read description text for annotation from file (use "-" to read from stdin)`},
 				cli.IntFlag{Name: "from", Usage: "Starting time (epoch seconds)"},
 				cli.IntFlag{Name: "to", Usage: "Ending time (epoch seconds)"},
 				cli.StringFlag{Name: "service, s", Usage: "Service name for annotation"},
@@ -68,6 +70,7 @@ var Command = cli.Command{
 				cli.StringFlag{Name: "service, s", Usage: "Service name for annotation"},
 				cli.StringFlag{Name: "title", Usage: "Title for annotation"},
 				cli.StringFlag{Name: "description", Usage: "Description for annotation"},
+				cli.StringFlag{Name: "description-file", Usage: `Read description text for annotation from file (use "-" to read from stdin)`},
 				cli.IntFlag{Name: "from", Usage: "Starting time (epoch seconds)"},
 				cli.IntFlag{Name: "to", Usage: "Ending time (epoch seconds)"},
 				cli.StringSliceFlag{
@@ -95,6 +98,7 @@ var Command = cli.Command{
 func doAnnotationsCreate(c *cli.Context) error {
 	title := c.String("title")
 	description := c.String("description")
+	descriptionFile := c.String("description-file")
 	from := c.Int64("from")
 	to := c.Int64("to")
 	service := c.String("service")
@@ -118,6 +122,25 @@ func doAnnotationsCreate(c *cli.Context) error {
 	if to == 0 {
 		_ = cli.ShowCommandHelp(c, "create")
 		return cli.NewExitError("`to` is a required field to create a graph annotation.", 1)
+	}
+
+	if description != "" && descriptionFile != "" {
+		_ = cli.ShowCommandHelp(c, "create")
+		return cli.NewExitError("specify one of `description` or `description-file`.", 1)
+	}
+
+	if descriptionFile != "" {
+		var (
+			b   []byte
+			err error
+		)
+		if descriptionFile == "-" {
+			b, err = io.ReadAll(os.Stdin)
+		} else {
+			b, err = os.ReadFile(descriptionFile)
+		}
+		logger.DieIf(err)
+		description = string(b)
 	}
 
 	client := mackerelclient.NewFromContext(c)
@@ -167,6 +190,7 @@ func doAnnotationsUpdate(c *cli.Context) error {
 	annotationID := c.String("id")
 	title := c.String("title")
 	description := c.String("description")
+	descriptionFile := c.String("description-file")
 	from := c.Int64("from")
 	to := c.Int64("to")
 	service := c.String("service")
@@ -190,6 +214,25 @@ func doAnnotationsUpdate(c *cli.Context) error {
 	if to == 0 {
 		_ = cli.ShowCommandHelp(c, "update")
 		return cli.NewExitError("`to` is a required field to update a graph annotation.", 1)
+	}
+
+	if description != "" && descriptionFile != "" {
+		_ = cli.ShowCommandHelp(c, "create")
+		return cli.NewExitError("specify one of `description` or `description-file`.", 1)
+	}
+
+	if descriptionFile != "" {
+		var (
+			b   []byte
+			err error
+		)
+		if descriptionFile == "-" {
+			b, err = io.ReadAll(os.Stdin)
+		} else {
+			b, err = os.ReadFile(descriptionFile)
+		}
+		logger.DieIf(err)
+		description = string(b)
 	}
 
 	client := mackerelclient.NewFromContext(c)

--- a/annotations/command.go
+++ b/annotations/command.go
@@ -23,7 +23,7 @@ var Command = cli.Command{
 		{
 			Name:      "create",
 			Usage:     "create a graph annotation",
-			ArgsUsage: "--title <title> [--description <descriptio>] --from <from> --to <to> --service|-s <service> [--role|-r <role>]",
+			ArgsUsage: "--title <title> [--description <description>] [--description-file <file-path>] --from <from> --to <to> --service|-s <service> [--role|-r <role>]",
 			Description: `
     Creates a graph annotation.
 `,
@@ -60,7 +60,7 @@ var Command = cli.Command{
 		{
 			Name:      "update",
 			Usage:     "update annotation",
-			ArgsUsage: "--id <id> [--title <title>] [--description <descriptio>] --from <from> --to <to> --service|-s <service> [--role|-r <role>]",
+			ArgsUsage: "--id <id> [--title <title>] [--description <description>] [--description-file <file-path>] --from <from> --to <to> --service|-s <service> [--role|-r <role>]",
 			Description: `
     Updates an annotation
 `,


### PR DESCRIPTION
Added `--description-file` option to `annotations create` and `annotations update` commands. You can also read from stdin by passing "-" in place of the file path.

## run test

### annotations create / read from stdin

```sh
echo "Hello." | ./mkr -conf /opt/homebrew/etc/mackerel-agent.conf annotations create --service test --title test --from $(date '+%s') --to $(date '+%s') --description-file -
```
```json
{
    "id": "4UsqfziHEew",
    "title": "test",
    "description": "Hello.\n",
    "from": 1689863144,
    "to": 1689863144,
    "service": "test"
}
```

### annotations update / read from stdin

```sh
echo "Hello2." | ./mkr -conf /opt/homebrew/etc/mackerel-agent.conf annotations update --id 4UsqfziHEew --service test --title test --from $(date '+%s') --to $(date '+%s') --description-file -
```
```json
{
    "id": "4UsqfziHEew",
    "title": "test",
    "description": "Hello2.\n",
    "from": 1689863321,
    "to": 1689863321,
    "service": "test"
}
```

### annotations create / read from file

```sh
echo "Hello" > description.txt
./mkr -conf /opt/homebrew/etc/mackerel-agent.conf annotations create --service test --title test --from $(date '+%s') --to $(date '+%s') --description-file description.txt
```
```json
{
    "id": "4UsqPc5eyqG",
    "title": "test",
    "description": "Hello\n",
    "from": 1689863441,
    "to": 1689863441,
    "service": "test"
}
```

### annotations update / read from file

```sh
echo "World" >> description.txt
./mkr -conf /opt/homebrew/etc/mackerel-agent.conf annotations update --id 4UsqPc5eyqG --service test --title test --from $(date '+%s') --to $(date '+%s') --description-file description.txt
```
```json
{
    "id": "4UsqPc5eyqG",
    "title": "test",
    "description": "Hello\nWorld\n",
    "from": 1689863488,
    "to": 1689863488,
    "service": "test"
}
```

### both --description and --description-file are specified

```sh
./mkr -conf /opt/homebrew/etc/mackerel-agent.conf annotations create --service test --title test --from $(date '+%s') --to $(date '+%s') --description "sample" --description-file description.txt
```
```sh
NAME:
   mkr annotations create - create a graph annotation

USAGE:
   mkr annotations create [command options] --title <title> [--description <descriptio>] --from <from> --to <to> --service|-s <service> [--role|-r <role>]

DESCRIPTION:

    Creates a graph annotation.


OPTIONS:
   --title value              Title for annotation
   --description value        Description for annotation
   --description-file value   Read description text for annotation from file (use "-" to read from stdin)
   --from value               Starting time (epoch seconds) (default: 0)
   --to value                 Ending time (epoch seconds) (default: 0)
   --service value, -s value  Service name for annotation
   --role value, -r value     Roles for annotation. Multiple choices are allowed

specify one of `description` or `description-file`.
```