### PR TITLE
update Go version to 1.21 and 1.20 by using reusable workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,15 @@ updates:
       interval: weekly
       time: "01:00"
       timezone: Asia/Tokyo
+    groups:
+      dev-dependencies:
+        patterns:
+          - "github.com/Songmu/goxz"
+          - "github.com/stretchr/testify"
+      stable-packages:
+        patterns:
+          - "golang.org/x/*"
+          - "github.com/mackerelio/*"
     open-pull-requests-limit: 10
   - package-ecosystem: github-actions
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,14 @@ updates:
   - package-ecosystem: docker
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
       time: "01:00"
       timezone: Asia/Tokyo
     open-pull-requests-limit: 10
   - package-ecosystem: gomod
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
       time: "01:00"
       timezone: Asia/Tokyo
     open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,46 +11,9 @@ env:
   DEBIAN_FRONTEND: noninteractive
 jobs:
   lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
-        with:
-          go-version-file: go.mod
-      - uses: golangci/golangci-lint-action@v3
+    uses: mackerelio/workflows/.github/workflows/go-lint.yml@v1.0.2
   test:
-    strategy:
-      matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - uses: actions/setup-go@v4
-        with:
-          go-version: 1.21.x
-      - run: |
-          go test -race -covermode atomic -coverprofile=profile.cov ./...
-        shell: bash
-      - uses: shogo82148/actions-goveralls@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-profile: profile.cov
-          parallel: true
-          flag-name: Go-${{ matrix.os }}
-  finish:
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: shogo82148/actions-goveralls@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true
+    uses: mackerelio/workflows/.github/workflows/go-test.yml@v1.0.2
   build:
     needs: [lint, test]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
             ${{ runner.os }}-go-
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.19.x
+          go-version: 1.21.x
       - run: |
           go test -race -covermode atomic -coverprofile=profile.cov ./...
         shell: bash
@@ -62,16 +62,11 @@ jobs:
             rpm devscripts debhelper fakeroot \
             crossbuild-essential-arm64 crossbuild-essential-armhf
           mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
-      - uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.19.x
-      - uses: actions/checkout@v4
+          go-version: 1.21.x
+          cache: true
       - run: make all
       - uses: actions/upload-artifact@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine AS builder
+FROM golang:1.21-alpine AS builder
 RUN apk add --no-cache make git
 WORKDIR /go/src/github.com/mackerelio/mkr/
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mackerelio/mkr
 
-go 1.18
+go 1.20
 
 require (
 	github.com/Songmu/goxz v0.9.1


### PR DESCRIPTION
- use Go 1.21 to build binaries and container image
- set minimal supported version to 1.20 (because checkers uses strings.CutPrefix)
- refactor workflows and dependabot config