### PR TITLE
accept UTF8-BOM when reading dashboard or monitor from JSON file

### DIFF
--- a/dashboards/command.go
+++ b/dashboards/command.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"os"
 
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
+
 	"github.com/mackerelio/mackerel-client-go"
 	"github.com/mackerelio/mkr/format"
 	"github.com/mackerelio/mkr/logger"
@@ -92,8 +95,10 @@ func doPushDashboard(c *cli.Context) error {
 	f := c.String("file-path")
 	src, err := os.Open(f)
 	logger.DieIf(err)
+	fallback := unicode.UTF8.NewDecoder()
+	r := transform.NewReader(src, unicode.BOMOverride(fallback))
 
-	dec := json.NewDecoder(src)
+	dec := json.NewDecoder(r)
 	var dashboard mackerel.Dashboard
 	err = dec.Decode(&dashboard)
 	logger.DieIf(err)

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/yudai/gojsondiff v1.0.0
 	golang.org/x/oauth2 v0.15.0
 	golang.org/x/sync v0.5.0
+	golang.org/x/text v0.14.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -62,7 +63,6 @@ require (
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/term v0.15.0 // indirect
-	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect

--- a/monitors/command.go
+++ b/monitors/command.go
@@ -17,6 +17,8 @@ import (
 	"github.com/urfave/cli"
 	"github.com/yudai/gojsondiff"
 	"github.com/yudai/gojsondiff/formatter"
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
 )
 
 var Command = cli.Command{
@@ -102,7 +104,9 @@ func monitorLoadRules(optFilePath string) ([]mackerel.Monitor, error) {
 	if err != nil {
 		return nil, err
 	}
-	return decodeMonitors(f)
+	fallback := unicode.UTF8.NewDecoder()
+	r := transform.NewReader(f, unicode.BOMOverride(fallback))
+	return decodeMonitors(r)
 }
 
 // decodeMonitors decodes monitors JSON.

--- a/monitors/command_test.go
+++ b/monitors/command_test.go
@@ -208,8 +208,9 @@ func TestMonitorLoadRulesWithBOM(t *testing.T) {
 	if err != nil {
 		t.Errorf("should not raise error: %v", err)
 	}
-	defer tmpFile.Close()
-
+	t.Cleanup(func() {
+		tmpFile.Close()
+	})
 	json := `{"monitors": []}`
 
 	_, err = tmpFile.WriteString(json)

--- a/monitors/command_test.go
+++ b/monitors/command_test.go
@@ -200,3 +200,33 @@ func TestDiffMonitorsWithScopes(t *testing.T) {
 		t.Errorf("expected:\n%s\n, output:\n%s\n", expected, diff)
 	}
 }
+
+func TestMonitorLoadRules(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "")
+	if err != nil {
+		t.Errorf("should not raise error: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	json := `{"monitors": []}`
+
+	_, err = tmpFile.WriteString(json)
+	if err != nil {
+		t.Errorf("should not raise error: %v", err)
+	}
+	_, err = monitorLoadRules(tmpFile.Name())
+	if err != nil {
+		t.Error("should accept JSON content no BOM")
+	}
+
+	utf8bom := "\xef\xbb\xbf"
+	tmpFile.Seek(0, 0)
+	_, err = tmpFile.WriteString(utf8bom + json)
+	if err != nil {
+		t.Errorf("should not raise error: %v", err)
+	}
+	_, err = monitorLoadRules(tmpFile.Name())
+	if err != nil {
+		t.Error("should accept JSON content with BOM")
+	}
+}

--- a/monitors/command_test.go
+++ b/monitors/command_test.go
@@ -201,7 +201,7 @@ func TestDiffMonitorsWithScopes(t *testing.T) {
 	}
 }
 
-func TestMonitorLoadRules(t *testing.T) {
+func TestMonitorLoadRulesWithBOM(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Errorf("should not raise error: %v", err)

--- a/monitors/command_test.go
+++ b/monitors/command_test.go
@@ -220,7 +220,10 @@ func TestMonitorLoadRules(t *testing.T) {
 	}
 
 	utf8bom := "\xef\xbb\xbf"
-	tmpFile.Seek(0, 0)
+	_, err = tmpFile.Seek(0, 0)
+	if err != nil {
+		t.Errorf("should not raise error: %v", err)
+	}
 	_, err = tmpFile.WriteString(utf8bom + json)
 	if err != nil {
 		t.Errorf("should not raise error: %v", err)

--- a/monitors/command_test.go
+++ b/monitors/command_test.go
@@ -2,6 +2,7 @@ package monitors
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/mackerelio/mackerel-client-go"
@@ -202,11 +203,11 @@ func TestDiffMonitorsWithScopes(t *testing.T) {
 }
 
 func TestMonitorLoadRulesWithBOM(t *testing.T) {
-	tmpFile, err := os.CreateTemp("", "")
+	dir := t.TempDir()
+	tmpFile, err := os.Create(filepath.Join(dir, "monitors.json"))
 	if err != nil {
 		t.Errorf("should not raise error: %v", err)
 	}
-	defer os.Remove(tmpFile.Name())
 
 	json := `{"monitors": []}`
 

--- a/monitors/command_test.go
+++ b/monitors/command_test.go
@@ -2,7 +2,6 @@ package monitors
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/mackerelio/mackerel-client-go"
@@ -203,14 +202,13 @@ func TestDiffMonitorsWithScopes(t *testing.T) {
 }
 
 func TestMonitorLoadRulesWithBOM(t *testing.T) {
-	dir := t.TempDir()
-	tmpFile, err := os.Create(filepath.Join(dir, "monitors.json"))
+	// XXX: t.TempDir is better, but it will cause "TempDir RemoveAll cleanup: remove C:\...\monitors.json: The process cannot access the file because it is being used by another process." error on Windows
+	tmpFile, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Errorf("should not raise error: %v", err)
 	}
-	t.Cleanup(func() {
-		tmpFile.Close()
-	})
+	defer os.Remove(tmpFile.Name())
+
 	json := `{"monitors": []}`
 
 	_, err = tmpFile.WriteString(json)

--- a/monitors/command_test.go
+++ b/monitors/command_test.go
@@ -208,6 +208,7 @@ func TestMonitorLoadRulesWithBOM(t *testing.T) {
 	if err != nil {
 		t.Errorf("should not raise error: %v", err)
 	}
+	defer tmpFile.Close()
 
 	json := `{"monitors": []}`
 


### PR DESCRIPTION
Passing a JSON file with a UTF-8 BOM to `mkr dashboards push --file-path` causes an error that is difficult for users to understand.

```
     error invalid character 'ï' looking for beginning of value
```

I understand that "JSON files must not contain a BOM", but I thought it would be more user-friendly to ignore the BOM part and read the file without making an error, so I made a patch.

Test
```
# original version 0.54.0
$ mkr dashboards push --file-path t-nobom.json
$ mkr dashboards push --file-path t-withbom.json
     error invalid character 'ï' looking for beginning of value

# (remove dashboards)

# patched version
$ ./mkr dashboards push --file-path t-nobom.json
$ ./mkr dashboards push --file-path t-withbom.json
```
[t-nobom.json](https://github.com/mackerelio/mkr/files/13956859/t-nobom.json)
[t-withbom.json](https://github.com/mackerelio/mkr/files/13956861/t-withbom.json)
