### PR TITLE
Always set CGO_ENABLED=0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ BIN := mkr
 VERSION := 0.55.0
 CURRENT_REVISION := $(shell git rev-parse --short HEAD)
 BUILD_LDFLAGS := "-w -s -X main.gitcommit=$(CURRENT_REVISION)"
+export CGO_ENABLED := 0
 
 .PHONY: all
 all: clean cross test rpm deb
@@ -16,7 +17,7 @@ test:
 
 .PHONY: build
 build:
-	CGO_ENABLED=0 go build -ldflags=$(BUILD_LDFLAGS) -o $(BIN) .
+	go build -ldflags=$(BUILD_LDFLAGS) -o $(BIN) .
 
 .PHONY: cross
 cross: devel-deps


### PR DESCRIPTION
Hi!

The latest release binaries seems to be build dynamic linked.
For example https://github.com/mackerelio/mkr/releases/download/v0.55.0/mkr_linux_amd64.tar.gz

```console
$ curl -sLO https://github.com/mackerelio/mkr/releases/download/v0.55.0/mkr_linux_amd64.tar.gz
$ tar xvf mkr_linux_amd64.tar.gz
$ ldd mkr_linux_amd64/mkr
linux-vdso.so.1 (0x00007ffe0359c000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f6c654a7000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f6c656de000)
```

But, the mkr binary in Debian packages are statically linked.

```console
$ ldd /usr/bin/mkr
        not a dynamic executable
```

I hope to use the release binaries in non-glibc environments (like Alpine Linux).


Currently, CGO_ENABLED=0 is set only when building via 'make build'. But the setting does not affect 'make cross', so release binaries seems dynamically linked.

This PR sets `CGO_ENABLED=0` always.

refs https://github.com/mackerelio/mkr/pull/515