### PR TITLE
Add `--jq` option to `org` sub command

### DIFF
--- a/org/app.go
+++ b/org/app.go
@@ -11,6 +11,7 @@ import (
 type orgApp struct {
 	client    mackerelclient.Client
 	outStream io.Writer
+	jqFilter  string
 }
 
 func (app *orgApp) run() error {
@@ -19,7 +20,7 @@ func (app *orgApp) run() error {
 		return err
 	}
 
-	err = format.PrettyPrintJSON(app.outStream, org, "")
+	err = format.PrettyPrintJSON(app.outStream, org, app.jqFilter)
 	logger.DieIf(err)
 	return nil
 }

--- a/org/app_test.go
+++ b/org/app_test.go
@@ -15,14 +15,36 @@ func TestOrgApp_Run(t *testing.T) {
 	testCases := []struct {
 		id       string
 		org      *mackerel.Org
+		jqFilter string
 		expected string
 	}{
 		{
-			id:  "default",
-			org: &mackerel.Org{Name: "sample-org"},
+			id:       "default",
+			org:      &mackerel.Org{Name: "sample-org"},
+			jqFilter: "",
 			expected: `{
     "name": "sample-org"
 }
+`,
+		},
+		{
+			id:       "jq_orgName",
+			org:      &mackerel.Org{Name: "sample-org"},
+			jqFilter: ".name",
+			expected: `sample-org
+`,
+		},
+		{
+			id:       "jq_emptyDisplayName",
+			org:      &mackerel.Org{Name: "sample-org"},
+			jqFilter: ".displayName",
+			expected: "\n",
+		},
+		{
+			id:       "jq_displayName",
+			org:      &mackerel.Org{Name: "sample-org", DisplayName: "Sample Org"},
+			jqFilter: ".displayName",
+			expected: `Sample Org
 `,
 		},
 	}
@@ -34,9 +56,11 @@ func TestOrgApp_Run(t *testing.T) {
 		)
 		t.Run(tc.id, func(t *testing.T) {
 			out := new(bytes.Buffer)
+			jqFilter := tc.jqFilter
 			app := &orgApp{
 				client:    client,
 				outStream: out,
+				jqFilter:  jqFilter,
 			}
 			assert.NoError(t, app.run())
 			assert.Equal(t, tc.expected, out.String())

--- a/org/command.go
+++ b/org/command.go
@@ -12,7 +12,7 @@ import (
 var Command = cli.Command{
 	Name:      "org",
 	Usage:     "Fetch organization",
-	ArgsUsage: "--jq <formula>",
+	ArgsUsage: "[--jq <formula>]",
 	Description: `
     Fetch organization.
     Requests APIs under "/api/v0/org". See https://mackerel.io/api-docs/entry/organizations .

--- a/org/command.go
+++ b/org/command.go
@@ -3,19 +3,24 @@ package org
 import (
 	"os"
 
+	"github.com/mackerelio/mkr/jq"
 	"github.com/mackerelio/mkr/mackerelclient"
 	"github.com/urfave/cli"
 )
 
 // Command is the definition of org subcommand
 var Command = cli.Command{
-	Name:  "org",
-	Usage: "Fetch organization",
+	Name:      "org",
+	Usage:     "Fetch organization",
+	ArgsUsage: "--jq <formula>",
 	Description: `
     Fetch organization.
     Requests APIs under "/api/v0/org". See https://mackerel.io/api-docs/entry/organizations .
 `,
 	Action: doOrg,
+	Flags: []cli.Flag{
+		jq.CommandLineFlag,
+	},
 }
 
 func doOrg(c *cli.Context) error {
@@ -27,5 +32,6 @@ func doOrg(c *cli.Context) error {
 	return (&orgApp{
 		client:    client,
 		outStream: os.Stdout,
+		jqFilter:  c.String("jq"),
 	}).run()
 }


### PR DESCRIPTION
It would be helpful if `mkr org` subcommand has `--jq` option like other subcommands.

For example:
```
$ mkr org --jq '.name'
myorg
$ mkr org --jq '.displayName'
My Organization
```

Here is a patch to add `--jq` option to `org` subcommand and test code.

I referred the code of `channels` subcommand.