### PR TITLE
Support query monitorings

### DIFF
--- a/monitors/command.go
+++ b/monitors/command.go
@@ -321,7 +321,7 @@ func validateRules(monitors []mackerel.Monitor, label string) (bool, error) {
 				return false, fmt.Errorf("Query Monitoring '%s' should have 'query'", m.Name)
 			}
 			if m.Operator == "" {
-				return false, fmt.Errorf("Query monitoring '%s' should have 'operator'", m.Operator)
+				return false, fmt.Errorf("Query monitoring '%s' should have 'operator'", m.Name)
 			}
 		default:
 			return false, fmt.Errorf("Unknown type is found: %s", m.MonitorType())

--- a/monitors/command.go
+++ b/monitors/command.go
@@ -154,6 +154,10 @@ func decodeMonitor(mes json.RawMessage) (mackerel.Monitor, error) {
 		m = &mackerel.MonitorExpression{}
 	case "anomalyDetection":
 		m = &mackerel.MonitorAnomalyDetection{}
+	case "query":
+		m = &mackerel.MonitorQuery{}
+	default:
+		return nil, fmt.Errorf("unknown type: %q", typeData.Type)
 	}
 	if err := json.Unmarshal(mes, m); err != nil {
 		return nil, err
@@ -309,6 +313,16 @@ func validateRules(monitors []mackerel.Monitor, label string) (bool, error) {
 				return false, err
 			}
 		case *mackerel.MonitorConnectivity:
+		case *mackerel.MonitorQuery:
+			if m.Name == "" {
+				return false, fmt.Errorf("Query Monitoring should have 'name'")
+			}
+			if m.Query == "" {
+				return false, fmt.Errorf("Query Monitoring '%s' should have 'query'", m.Name)
+			}
+			if m.Operator == "" {
+				return false, fmt.Errorf("Query monitoring '%s' should have 'operator'", m.Operator)
+			}
 		default:
 			return false, fmt.Errorf("Unknown type is found: %s", m.MonitorType())
 		}

--- a/monitors/command_test.go
+++ b/monitors/command_test.go
@@ -23,32 +23,32 @@ func TestIsSameMonitor(t *testing.T) {
 }
 
 func TestValidateRoles(t *testing.T) {
-	{
+	t.Run("connectivitiy", func(t *testing.T) {
 		a := &mackerel.MonitorConnectivity{ID: "12345", Name: "foo", Type: "connectivity"}
 
 		ret, err := validateRules([](mackerel.Monitor){a}, "test monitor")
 		if ret != true {
 			t.Errorf("should validate the rule: %s", err.Error())
 		}
-	}
+	})
 
-	{
+	t.Run("valid anomalyDetection", func(t *testing.T) {
 		a := &mackerel.MonitorAnomalyDetection{ID: "12345", Name: "anomaly", Type: "anomalyDetection", WarningSensitivity: "sensitive", Scopes: []string{"MyService: MyRole"}}
 
 		ret, err := validateRules([](mackerel.Monitor){a}, "anomaly detection monitor")
 		if ret != true {
 			t.Errorf("should validate the rule: %s", err.Error())
 		}
-	}
+	})
 
-	{
+	t.Run("invalid anomalyDetection", func(t *testing.T) {
 		a := &mackerel.MonitorAnomalyDetection{ID: "12345", Name: "anomaly", Type: "anomalyDetection", WarningSensitivity: "sensitive"}
 
 		ret, err := validateRules([](mackerel.Monitor){a}, "anomaly detection monitor")
 		if ret == true || err == nil {
 			t.Error("should invalidate the rule")
 		}
-	}
+	})
 }
 
 func pfloat64(x float64) *float64 {

--- a/monitors/command_test.go
+++ b/monitors/command_test.go
@@ -49,6 +49,24 @@ func TestValidateRoles(t *testing.T) {
 			t.Error("should invalidate the rule")
 		}
 	})
+
+	t.Run("valid query monitoring rule", func(t *testing.T) {
+		a := &mackerel.MonitorQuery{Name: "name", Type: "query", Query: "http.monitor.count", Operator: "<"}
+
+		ret, err := validateRules([](mackerel.Monitor){a}, "query monitor")
+		if !ret {
+			t.Errorf("should validate the rule: %v", err)
+		}
+	})
+
+	t.Run("invalid query monitoring rule", func(t *testing.T) {
+		a := &mackerel.MonitorQuery{Name: "name", Type: "query", Operator: "<"}
+
+		ret, err := validateRules([](mackerel.Monitor){a}, "query monitor")
+		if ret == true || err == nil {
+			t.Error("should invalidate the rule")
+		}
+	})
 }
 
 func pfloat64(x float64) *float64 {


### PR DESCRIPTION
I make mkr support "query monitoring", which is a new monitoring rule on Mackerel.

## example

First I have got monitors.json using `mkr monitors pull` and edited it to add a new query rule `new query`.
Then, I tested two command `diff` and `push` as following.

``` console
% ./mkr monitors diff
Summary: 0 modify, 1 append, 0 remove

+{
+  "name": "new query",
+  "type": "query",
+  "query": "http.client.duration.p90{service.name=\"web-app\"}",
+  "operator": "<",
+  "warning": 1,
+  "critical": null,
+  "legend": "{{http.status_code}}"
+},
% ./mkr monitors push
      info Create a new rule.
{
  "name": "new query",
  "type": "query",
  "query": "http.client.duration.p90{service.name=\"web-app\"}",
  "operator": "<",
  "warning": 1,
  "critical": null,
  "legend": "{{http.status_code}}"
},
```

After that, I checked the new rule was created through https://mackerel.io/my/monitors