### PR TITLE
Use strings.Replacer and strings.ReplaceAll where appropriate

### DIFF
--- a/checks/checker.go
+++ b/checks/checker.go
@@ -75,7 +75,7 @@ func (re *result) tapFormat(num int) string {
 	}
 	b, _ := yaml.Marshal(re)
 	// indent
-	yamlStr := "  " + strings.Replace(strings.TrimSpace(string(b)), "\n", "\n  ", -1)
+	yamlStr := "  " + strings.ReplaceAll(strings.TrimSpace(string(b)), "\n", "\n  ")
 	return fmt.Sprintf("%s %d - %s\n  ---\n%s\n  ...",
 		okOrNot, num, re.Name, yamlStr)
 }

--- a/format/format.go
+++ b/format/format.go
@@ -34,16 +34,13 @@ func PrettyPrintJSON(outStream io.Writer, src interface{}, query string) error {
 	return jq.FilterJSON(outStream, src, query)
 }
 
+var angleBracketReplacer = strings.NewReplacer(`\u003c`, "<", `\u003e`, ">")
+
 // JSONMarshalIndent call json.MarshalIndent and replace encoded angle brackets
 func JSONMarshalIndent(src interface{}, prefix, indent string) string {
 	dataRaw, err := json.MarshalIndent(src, prefix, indent)
 	logger.DieIf(err)
-	return replaceAngleBrackets(string(dataRaw))
-}
-
-func replaceAngleBrackets(s string) string {
-	s = strings.Replace(s, "\\u003c", "<", -1)
-	return strings.Replace(s, "\\u003e", ">", -1)
+	return angleBracketReplacer.Replace(string(dataRaw))
 }
 
 // ISO8601Extended format


### PR DESCRIPTION
I replaced some code using `strings.Replace(..., -1)` to use `strings.Replacer` and `strings.ReplaceAll` where they are more appropriate in my opinion.
