### PR TITLE
Fix CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     uses: mackerelio/workflows/.github/workflows/go-test.yml@v1.2.0
   build:
     needs: [lint, test]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
     steps:
       - run: |
@@ -43,7 +43,7 @@ jobs:
 
   release:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/download-artifact@v4
@@ -86,7 +86,7 @@ jobs:
   build_images_and_push:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Same as https://github.com/mackerelio/mackerel-agent-plugins/pull/1247 .

The CI for the master branch is failing due to the absence of the build-essential:native package, as seen in [this run](https://github.com/mackerelio/mkr/actions/runs/12924557525/job/36043964051). It appears that the cause is the change to Ubuntu 24.04, as the runner is specified to use ubuntu-latest in GHA.
This pull request specifies the runner to use ubuntu-22.04.