### PR TITLE
update mackerel-client-go to v0.36.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/jpillora/backoff v1.0.0
 	github.com/mackerelio/checkers v0.2.0
 	github.com/mackerelio/mackerel-agent v0.84.0
-	github.com/mackerelio/mackerel-client-go v0.34.0
+	github.com/mackerelio/mackerel-client-go v0.36.0
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/motemen/go-colorine v0.0.0-20180816141035-45d19169413a
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/mackerelio/golib v1.2.1 h1:SDcDn6Jw3p9bi1N0bg1Z/ilG5qcBB23qL8xNwrU0gg
 github.com/mackerelio/golib v1.2.1/go.mod h1:b8ZaapsHGH1FlEJlCqfD98CqafLeyMevyATDlID2BsM=
 github.com/mackerelio/mackerel-agent v0.84.0 h1:tfFIGbPdiRiUsZG7Nd4o5/tpR76Bgk1NBVs6USJCQHo=
 github.com/mackerelio/mackerel-agent v0.84.0/go.mod h1:kVwLWoJZmcs1mhLnsMUihdxUKgfK4edMkvJMCgBE43M=
-github.com/mackerelio/mackerel-client-go v0.34.0 h1:p7m2ceyqn3iihIb08URCb/pO5gs30IWCJKStQAI5ARc=
-github.com/mackerelio/mackerel-client-go v0.34.0/go.mod h1:YEWy40Ybr+Z75TvQw0t9/KYO0ZfPW2GrbCJhRp0UHpY=
+github.com/mackerelio/mackerel-client-go v0.36.0 h1:/dLedCmGWpo1cIKi5BB8QYtbA8w/R8McieleQ+Vme8w=
+github.com/mackerelio/mackerel-client-go v0.36.0/go.mod h1:EJom2FXbK0Akv61dVsRiH9oKggk4IWlgb6hrQtGK1Z4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=


### PR DESCRIPTION
mackerel-client-go v0.35.0 and v0.36.0 support new fields in some APIs updated recently.