### PR TITLE
Implement find alert logs command

### DIFF
--- a/alerts/command.go
+++ b/alerts/command.go
@@ -70,6 +70,15 @@ var Command = cli.Command{
 				cli.BoolFlag{Name: "verbose, v", Usage: "Verbose output mode"},
 			},
 		},
+		{
+			Name:      "logs",
+			Usage:     "get alert logs",
+			ArgsUsage: "<alertId>",
+			Description: `
+		Get alert logs.
+			`,
+			Action: findAlertLogs,
+		},
 	},
 }
 
@@ -403,7 +412,7 @@ func findAlertLogs(c *cli.Context) error {
 		cli.ShowCommandHelpAndExit(c, "alerts", 1)
 	}
 
-	alertId := c.Args()[0]
+	alertId := c.Args().Get(0)
 
 	client := mackerelclient.NewFromContext(c)
 	logs, err := client.FindAlertLogs(alertId, nil)

--- a/alerts/command.go
+++ b/alerts/command.go
@@ -397,3 +397,20 @@ func doAlertsClose(c *cli.Context) error {
 	}
 	return nil
 }
+
+func findAlertLogs(c *cli.Context) error {
+	if len(c.Args()) != 1 {
+		cli.ShowCommandHelpAndExit(c, "alerts", 1)
+	}
+
+	alertId := c.Args()[0]
+
+	client := mackerelclient.NewFromContext(c)
+	logs, err := client.FindAlertLogs(alertId, nil)
+	logger.DieIf(err)
+
+	err = format.PrettyPrintJSON(os.Stdout, logs, "")
+	logger.DieIf(err)
+
+	return nil
+}

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,6 @@ github.com/mackerelio/golib v1.2.1 h1:SDcDn6Jw3p9bi1N0bg1Z/ilG5qcBB23qL8xNwrU0gg
 github.com/mackerelio/golib v1.2.1/go.mod h1:b8ZaapsHGH1FlEJlCqfD98CqafLeyMevyATDlID2BsM=
 github.com/mackerelio/mackerel-agent v0.84.0 h1:tfFIGbPdiRiUsZG7Nd4o5/tpR76Bgk1NBVs6USJCQHo=
 github.com/mackerelio/mackerel-agent v0.84.0/go.mod h1:kVwLWoJZmcs1mhLnsMUihdxUKgfK4edMkvJMCgBE43M=
-github.com/mackerelio/mackerel-client-go v0.36.0 h1:/dLedCmGWpo1cIKi5BB8QYtbA8w/R8McieleQ+Vme8w=
-github.com/mackerelio/mackerel-client-go v0.36.0/go.mod h1:EJom2FXbK0Akv61dVsRiH9oKggk4IWlgb6hrQtGK1Z4=
 github.com/mackerelio/mackerel-client-go v0.37.0 h1:53s5mP1JpCB8JCPpz1aP3iyvfGFC+pOA7L05ZgEmNA8=
 github.com/mackerelio/mackerel-client-go v0.37.0/go.mod h1:EJom2FXbK0Akv61dVsRiH9oKggk4IWlgb6hrQtGK1Z4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=


### PR DESCRIPTION
Implemented getting alert logs command

- https://pkg.go.dev/github.com/mackerelio/mackerel-client-go#Client.FindAlertLogs

```
NAME:
   mkr alerts logs - get alert logs

USAGE:
   mkr alerts logs [command options] <alertId> [--limit | -l] [--jq <formula>]

DESCRIPTION:

    Get alert logs.


OPTIONS:
   --limit value, -l value  Set the number of alert logs to display (default: 100)
   --jq value               Filter response values using jq syntax

```