### PR TITLE
Get plugin's releaseTag from the releases URL instead of using api

### DIFF
--- a/plugin/install_target.go
+++ b/plugin/install_target.go
@@ -208,7 +208,7 @@ func extractTagFromReleasesURL(u *url.URL) (string, error) {
 	segments := strings.Split(strings.Trim(u.EscapedPath(), "/"), "/")
 	for i := 0; i < len(segments)-1; i++ {
 		if segments[i] == "releases" && i+1 < len(segments) && segments[i+1] == "tag" {
-			// 末尾がタグ
+			// Ends with a tag
 			raw := path.Base(u.EscapedPath())
 			tag, err := url.PathUnescape(raw)
 			if err != nil {

--- a/plugin/install_target.go
+++ b/plugin/install_target.go
@@ -173,8 +173,7 @@ func (it *installTarget) getTagFromReleasesURL(owner, repo string) (string, erro
 		},
 	}
 
-	ctx := context.Background()
-	req, err := http.NewRequestWithContext(ctx, http.MethodHead, latestURL, nil)
+	req, err := http.NewRequest(http.MethodHead, latestURL, nil)
 	if err != nil {
 		return "", err
 	}
@@ -183,7 +182,7 @@ func (it *installTarget) getTagFromReleasesURL(owner, repo string) (string, erro
 	if err != nil {
 		return "", err
 	}
-	io.Copy(io.Discard, resp.Body)
+	io.Copy(io.Discard, resp.Body) //nolint:errcheck
 	defer resp.Body.Close()
 
 	loc := resp.Header.Get("Location")


### PR DESCRIPTION
Since we sometimes hit the GitHub API rate limit when running mkr plugin install across many servers using our provisioning tool, we added code to pull the latest version straight from the github.com URL.