### PR TITLE
Add traces get command for trace retrieval

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mackerelio/mkr/plugin"
 	"github.com/mackerelio/mkr/services"
 	"github.com/mackerelio/mkr/status"
+	"github.com/mackerelio/mkr/traces"
 	"github.com/mackerelio/mkr/users"
 	"github.com/mackerelio/mkr/wrap"
 	"github.com/urfave/cli/v3"
@@ -43,4 +44,5 @@ var Commands = []*cli.Command{
 	aws_integrations.Command,
 	metric_names.Command,
 	users.CommandUsers,
+	traces.Command,
 }

--- a/mackerelclient/client.go
+++ b/mackerelclient/client.go
@@ -18,6 +18,7 @@ type Client interface {
 	CreateHostContext(ctx context.Context, param *mackerel.CreateHostParam) (string, error)
 	UpdateHostStatusContext(ctx context.Context, hostID string, status string) error
 	ListHostMetricNamesContext(ctx context.Context, id string) ([]string, error)
+	GetTraceContext(ctx context.Context, traceID string) (*mackerel.TraceResponse, error)
 	// below mock needed implemented.
 	FindWithClosedAlertsContext(ctx context.Context) (*mackerel.AlertsResp, error)
 	FindWithClosedAlertsByNextIDContext(ctx context.Context, nextID string) (*mackerel.AlertsResp, error)

--- a/mackerelclient/mock_client.go
+++ b/mackerelclient/mock_client.go
@@ -19,6 +19,7 @@ type MockClient struct {
 	createHostCallback          func(param *mackerel.CreateHostParam) (string, error)
 	updateHostStatusCallback    func(hostID string, status string) error
 	listHostMetricNamesCallback func(id string) ([]string, error)
+	getTraceCallback            func(traceID string) (*mackerel.TraceResponse, error)
 }
 
 // MockClientOption represents an option of mock client of Mackerel API
@@ -191,6 +192,21 @@ func (c *MockClient) FindUsersContext(ctx context.Context) ([]*mackerel.User, er
 func MockFindUsers(callback func() ([]*mackerel.User, error)) MockClientOption {
 	return func(c *MockClient) {
 		c.findUsersCallback = callback
+	}
+}
+
+// GetTraceContext returns the trace of the specified trace ID using the callback set by MockGetTrace
+func (c *MockClient) GetTraceContext(ctx context.Context, traceID string) (*mackerel.TraceResponse, error) {
+	if c.getTraceCallback != nil {
+		return c.getTraceCallback(traceID)
+	}
+	return nil, errCallbackNotFound("GetTrace")
+}
+
+// MockGetTrace returns an option to set the callback of GetTrace
+func MockGetTrace(callback func(traceID string) (*mackerel.TraceResponse, error)) MockClientOption {
+	return func(c *MockClient) {
+		c.getTraceCallback = callback
 	}
 }
 

--- a/traces/app.go
+++ b/traces/app.go
@@ -1,0 +1,27 @@
+package traces
+
+import (
+	"context"
+	"io"
+
+	"github.com/mackerelio/mkr/format"
+	"github.com/mackerelio/mkr/logger"
+	"github.com/mackerelio/mkr/mackerelclient"
+)
+
+type tracesApp struct {
+	client    mackerelclient.Client
+	outStream io.Writer
+	jqFilter  string
+}
+
+func (app *tracesApp) getTrace(ctx context.Context, traceID string) error {
+	trace, err := app.client.GetTraceContext(ctx, traceID)
+	if err != nil {
+		return err
+	}
+
+	err = format.PrettyPrintJSON(app.outStream, trace, app.jqFilter)
+	logger.DieIf(err)
+	return nil
+}

--- a/traces/app_test.go
+++ b/traces/app_test.go
@@ -1,0 +1,95 @@
+package traces
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/mackerelio/mackerel-client-go"
+	"github.com/mackerelio/mkr/mackerelclient"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTracesApp_getTrace(t *testing.T) {
+	traceID := "0123456789abcdef0123456789abcdef"
+
+	testCases := []struct {
+		id       string
+		trace    *mackerel.TraceResponse
+		jqFilter string
+		expected string
+	}{
+		{
+			id: "default",
+			trace: &mackerel.TraceResponse{
+				Spans: []*mackerel.Span{
+					{
+						TraceID:   traceID,
+						SpanID:    "0123456780123456",
+						Name:      "test-span",
+						Kind:      mackerel.SpanKindInternal,
+						StartTime: time.Date(2025, 7, 9, 14, 3, 2, 0, time.UTC),
+						EndTime:   time.Date(2025, 7, 9, 14, 3, 3, 0, time.UTC),
+					},
+				},
+			},
+			expected: `{
+    "spans": [
+        {
+            "traceId": "0123456789abcdef0123456789abcdef",
+            "spanId": "0123456780123456",
+            "traceState": "",
+            "name": "test-span",
+            "kind": "internal",
+            "startTime": "2025-07-09T14:03:02Z",
+            "endTime": "2025-07-09T14:03:03Z",
+            "attributes": null,
+            "droppedAttributesCount": 0,
+            "events": null,
+            "droppedEventsCount": 0,
+            "links": null,
+            "droppedLinksCount": 0,
+            "status": null,
+            "resource": null,
+            "scope": null
+        }
+    ]
+}
+`,
+		},
+		{
+			id:       "jq",
+			trace:    &mackerel.TraceResponse{Spans: []*mackerel.Span{{Name: "test-span"}}},
+			jqFilter: ".spans[].name",
+			expected: `test-span
+`,
+		},
+		{
+			id:    "no spans",
+			trace: &mackerel.TraceResponse{Spans: []*mackerel.Span{}},
+			expected: `{
+    "spans": []
+}
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.id, func(t *testing.T) {
+			client := mackerelclient.NewMockClient(
+				mackerelclient.MockGetTrace(func(id string) (*mackerel.TraceResponse, error) {
+					assert.Equal(t, traceID, id)
+					return tc.trace, nil
+				}),
+			)
+			out := new(bytes.Buffer)
+			app := &tracesApp{
+				client:    client,
+				outStream: out,
+				jqFilter:  tc.jqFilter,
+			}
+			assert.NoError(t, app.getTrace(t.Context(), traceID))
+			assert.Equal(t, tc.expected, out.String())
+		})
+	}
+}

--- a/traces/command.go
+++ b/traces/command.go
@@ -1,0 +1,53 @@
+package traces
+
+import (
+	"context"
+	"os"
+
+	"github.com/mackerelio/mkr/jq"
+	"github.com/mackerelio/mkr/mackerelclient"
+	"github.com/urfave/cli/v3"
+)
+
+// Command is the definition of traces subcommand
+var Command = &cli.Command{
+	Name:  "traces",
+	Usage: "Fetch trace information",
+	Description: `
+    Fetch trace information. With "get" subcommand, get detailed trace information for the specified trace ID.
+    Requests APIs under "/api/v0/traces". See https://mackerel.io/api-docs/entry/traces .
+`,
+	Commands: []*cli.Command{
+		{
+			Name:      "get",
+			Usage:     "get trace",
+			ArgsUsage: "<traceId> [--jq <formula>]",
+			Description: `
+    Get detailed trace information for the specified trace ID.
+    Requests "GET /api/v0/traces/<traceId>". See https://mackerel.io/api-docs/entry/traces#get .
+`,
+			Action: doTracesGet,
+			Flags: []cli.Flag{
+				jq.CommandLineFlag,
+			},
+		},
+	},
+}
+
+func doTracesGet(ctx context.Context, c *cli.Command) error {
+	if c.Args().Len() != 1 {
+		cli.ShowSubcommandHelpAndExit(c, 1)
+	}
+
+	traceID := c.Args().Get(0)
+	client, err := mackerelclient.New(c.String("conf"), c.String("apibase"))
+	if err != nil {
+		return err
+	}
+
+	return (&tracesApp{
+		client:    client,
+		outStream: os.Stdout,
+		jqFilter:  c.String("jq"),
+	}).getTrace(ctx, traceID)
+}


### PR DESCRIPTION
I added traces get command

```
11:49 ❯ ./mkr traces get --help
NAME:
   mkr traces get - get trace

USAGE:
   mkr traces get [options] <traceId> [--jq <formula>]

DESCRIPTION:

       Get detailed trace information for the specified trace ID.
       Requests "GET /api/v0/traces/<traceId>". See https://mackerel.io/api-docs/entry/traces#get .


OPTIONS:
   --jq string  Filter response values using jq syntax
   --help, -h   show help

GLOBAL OPTIONS:
   --conf file    Config file path (default: "/Users/kga/Library/mackerel-agent/mackerel-agent.conf")
   --apibase URL  API Base URL (default: "https://api.mackerelio.com")
   --quiet, -q    Suppress info-level output

```

## TODO

- [x] Remove `replace` directive in go.mod once mackerel-client-go traces support is officially released
- [x] Update to official mackerel-client-go version
- [x] Test with official API