### PR TITLE
apm: add http-server-stats subcommand

### DIFF
--- a/apm/app.go
+++ b/apm/app.go
@@ -1,0 +1,38 @@
+package apm
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+
+	"github.com/mackerelio/mackerel-client-go"
+
+	"github.com/mackerelio/mkr/mackerelclient"
+)
+
+type appLogger interface {
+	Log(string, string)
+	Error(error)
+}
+
+type httpServerStatsApp struct {
+	client    mackerelclient.Client
+	outStream io.Writer
+	logger    appLogger
+}
+
+func (app *httpServerStatsApp) listHTTPServerStats(ctx context.Context, param *mackerel.ListHTTPServerStatsParam) error {
+	stats, err := app.client.ListHTTPServerStatsContext(ctx, param)
+	if err != nil {
+		app.logger.Error(err)
+		return err
+	}
+
+	encoder := json.NewEncoder(app.outStream)
+	encoder.SetIndent("", "    ")
+	if err := encoder.Encode(stats.Results); err != nil {
+		app.logger.Error(err)
+		return err
+	}
+	return nil
+}

--- a/apm/app_test.go
+++ b/apm/app_test.go
@@ -1,0 +1,18 @@
+package apm
+
+import (
+	"fmt"
+	"io"
+)
+
+type testLogger struct {
+	w io.Writer
+}
+
+func (l *testLogger) Log(prefix, message string) {
+	fmt.Fprintln(l.w, prefix, message)
+}
+
+func (l *testLogger) Error(err error) {
+	fmt.Fprintln(l.w, err.Error())
+}

--- a/apm/command.go
+++ b/apm/command.go
@@ -48,13 +48,24 @@ var httpServerStatsCommand = &cli.Command{
 			Required:  false,
 			TakesFile: false,
 		},
+		&cli.StringFlag{
+			Name:      "route",
+			Usage:     "Filter by route",
+			Aliases:   []string{},
+			Required:  false,
+			TakesFile: false,
+		},
 		&cli.TimestampFlag{
 			Name:      "from",
 			Usage:     "Start timestamp",
 			Aliases:   []string{},
 			Required:  false,
 			TakesFile: false,
-			Value:     time.Now().Truncate(time.Minute).Add(-30 * time.Minute),
+			Config: cli.TimestampConfig{
+				Timezone: time.Local,
+				Layouts:  []string{time.RFC3339, time.DateTime},
+			},
+			Value: time.Now().Truncate(time.Minute).Add(-30 * time.Minute),
 		},
 		&cli.TimestampFlag{
 			Name:      "to",
@@ -62,7 +73,11 @@ var httpServerStatsCommand = &cli.Command{
 			Aliases:   []string{},
 			Required:  false,
 			TakesFile: false,
-			Value:     time.Now().Truncate(time.Minute),
+			Config: cli.TimestampConfig{
+				Timezone: time.Local,
+				Layouts:  []string{time.RFC3339, time.DateTime},
+			},
+			Value: time.Now().Truncate(time.Minute),
 		},
 		&cli.IntFlag{
 			Name:      "page",
@@ -93,6 +108,9 @@ func doHTTPServerStats(ctx context.Context, c *cli.Command) error {
 	}
 	if env := c.String("environment"); env != "" {
 		param.Environment = &env
+	}
+	if route := c.String("route"); route != "" {
+		param.Route = &route
 	}
 	if page := c.Int("page"); page != 0 {
 		param.Page = &page

--- a/apm/command.go
+++ b/apm/command.go
@@ -1,0 +1,101 @@
+package apm
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/mackerelio/mackerel-client-go"
+
+	"github.com/mackerelio/mkr/logger"
+	"github.com/mackerelio/mkr/mackerelclient"
+	"github.com/urfave/cli/v3"
+)
+
+// Command is the definition of apm subcommand
+var Command = &cli.Command{
+	Name:  "apm",
+	Usage: "APM related commands",
+	Commands: []*cli.Command{
+		httpServerStatsCommand,
+	},
+}
+
+// httpServerStatsCommand is the definition of http-server-stats subcommand
+var httpServerStatsCommand = &cli.Command{
+	Name:      "http-server-stats",
+	Usage:     "List HTTP server stats of a service",
+	ArgsUsage: "[--service <serviceName>]",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:      "service",
+			Usage:     "Service name",
+			Aliases:   []string{"s"},
+			Required:  true,
+			TakesFile: false,
+		},
+		&cli.StringFlag{
+			Name:      "service-namespace",
+			Usage:     "Service namespace",
+			Aliases:   []string{},
+			Required:  false,
+			TakesFile: false,
+		},
+		&cli.StringFlag{
+			Name:      "environment",
+			Usage:     "Environment name",
+			Aliases:   []string{},
+			Required:  false,
+			TakesFile: false,
+		},
+		&cli.TimestampFlag{
+			Name:      "from",
+			Usage:     "Start timestamp",
+			Aliases:   []string{},
+			Required:  false,
+			TakesFile: false,
+			Value:     time.Now().Truncate(time.Minute).Add(-30 * time.Minute),
+		},
+		&cli.TimestampFlag{
+			Name:      "to",
+			Usage:     "End timestamp",
+			Aliases:   []string{},
+			Required:  false,
+			TakesFile: false,
+			Value:     time.Now().Truncate(time.Minute),
+		},
+		&cli.IntFlag{
+			Name:      "page",
+			Usage:     "Page number",
+			Aliases:   []string{},
+			Required:  false,
+			TakesFile: false,
+			Value:     1,
+		},
+	},
+	Action: doHTTPServerStats,
+}
+
+func doHTTPServerStats(ctx context.Context, c *cli.Command) error {
+	client := mackerelclient.NewFromCliCommand(c)
+	app := &httpServerStatsApp{
+		client:    client,
+		logger:    logger.New(),
+		outStream: os.Stdout,
+	}
+	param := &mackerel.ListHTTPServerStatsParam{
+		ServiceName: c.String("service"),
+		From:        c.Timestamp("from").Unix(),
+		To:          c.Timestamp("to").Unix(),
+	}
+	if ns := c.String("service-namespace"); ns != "" {
+		param.ServiceNamespace = &ns
+	}
+	if env := c.String("environment"); env != "" {
+		param.Environment = &env
+	}
+	if page := c.Int("page"); page != 0 {
+		param.Page = &page
+	}
+	return app.listHTTPServerStats(ctx, param)
+}

--- a/apm/command_test.go
+++ b/apm/command_test.go
@@ -1,0 +1,29 @@
+package apm
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/mackerelio/mackerel-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mackerelio/mkr/mackerelclient"
+)
+
+func TestDoHTTPServerStats(t *testing.T) {
+	client := mackerelclient.NewMockClient(mackerelclient.MockListHTTPServerStats(func(param *mackerel.ListHTTPServerStatsParam) (*mackerel.HTTPServerStatsPageConnection, error) {
+		assert.Equal(t, "service-name", param.ServiceName)
+		return &mackerel.HTTPServerStatsPageConnection{}, nil
+	}))
+	var buf bytes.Buffer
+	app := &httpServerStatsApp{
+		client:    client,
+		logger:    &testLogger{&buf},
+		outStream: &buf,
+	}
+	err := app.listHTTPServerStats(t.Context(), &mackerel.ListHTTPServerStatsParam{
+		ServiceName: "service-name",
+	})
+	require.NoError(t, err)
+}

--- a/commands.go
+++ b/commands.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/mackerelio/mkr/alerts"
 	"github.com/mackerelio/mkr/annotations"
+	"github.com/mackerelio/mkr/apm"
 	"github.com/mackerelio/mkr/aws_integrations"
 	"github.com/mackerelio/mkr/channels"
 	"github.com/mackerelio/mkr/checks"
@@ -43,4 +44,5 @@ var Commands = []*cli.Command{
 	aws_integrations.Command,
 	metric_names.Command,
 	users.CommandUsers,
+	apm.Command,
 }

--- a/mackerelclient/client.go
+++ b/mackerelclient/client.go
@@ -46,4 +46,5 @@ type Client interface {
 	CreateMonitorContext(ctx context.Context, param mackerel.Monitor) (mackerel.Monitor, error)
 	DeleteMonitorContext(ctx context.Context, monitorID string) (mackerel.Monitor, error)
 	UpdateMonitorContext(ctx context.Context, monitorID string, param mackerel.Monitor) (mackerel.Monitor, error)
+	ListHTTPServerStatsContext(ctx context.Context, param *mackerel.ListHTTPServerStatsParam) (*mackerel.HTTPServerStatsPageConnection, error)
 }

--- a/mackerelclient/mock_client.go
+++ b/mackerelclient/mock_client.go
@@ -19,6 +19,7 @@ type MockClient struct {
 	createHostCallback          func(param *mackerel.CreateHostParam) (string, error)
 	updateHostStatusCallback    func(hostID string, status string) error
 	listHostMetricNamesCallback func(id string) ([]string, error)
+	listHTTPServerStatsCallback func(param *mackerel.ListHTTPServerStatsParam) (*mackerel.HTTPServerStatsPageConnection, error)
 }
 
 // MockClientOption represents an option of mock client of Mackerel API
@@ -191,6 +192,21 @@ func (c *MockClient) FindUsersContext(ctx context.Context) ([]*mackerel.User, er
 func MockFindUsers(callback func() ([]*mackerel.User, error)) MockClientOption {
 	return func(c *MockClient) {
 		c.findUsersCallback = callback
+	}
+}
+
+// HTTPServerStats ...
+func (c *MockClient) ListHTTPServerStatsContext(ctx context.Context, param *mackerel.ListHTTPServerStatsParam) (*mackerel.HTTPServerStatsPageConnection, error) {
+	if c.listHTTPServerStatsCallback != nil {
+		return c.listHTTPServerStatsCallback(param)
+	}
+	return nil, errCallbackNotFound("HTTPServerStats")
+}
+
+// MockListHTTPServerStats returns an option to set the callback of ListHTTPServerStats
+func MockListHTTPServerStats(callback func(param *mackerel.ListHTTPServerStatsParam) (*mackerel.HTTPServerStatsPageConnection, error)) MockClientOption {
+	return func(c *MockClient) {
+		c.listHTTPServerStatsCallback = callback
 	}
 }
 


### PR DESCRIPTION
## motivation

I want to use [http-stats api](https://mackerel.io/api-docs/entry/apm#http-server-stats).

## usage

```console
$ mkr apm http-server-stats --service backend --service-namespace=ns
[
    {
        "method": "GET",
        "route": "/server-status",
        "totalMillis": 93,
        "averageMillis": 0.188,
        "approxP95Millis": 0.233,
        "errorRatePercentage": 0,
        "requestCount": 840
    }
]
```

```console
$ mkr apm http-server-stats -h
NAME:
   mkr apm http-server-stats - List HTTP server stats of a service

USAGE:
   mkr apm http-server-stats [options] [--service <serviceName>]

OPTIONS:
   --service string, -s string  Service name
   --service-namespace string   Service namespace
   --environment string         Environment name
   --from time                  Start timestamp (default: 2026-06-02 16:32:00 +0900 JST)
   --to time                    End timestamp (default: 2026-06-02 17:02:00 +0900 JST)
   --page int                   Page number (default: 1)
   --help, -h                   show help

GLOBAL OPTIONS:
   --conf file    Config file path (default: "/etc/mackerel-agent/mackerel-agent.conf")
   --apibase URL  API Base URL (default: "https://api.mackerelio.com")
   --quiet, -q    Suppress info-level output
```

## limitation

* does not cover all parameters, such as *version*, *route* or *perPage*