### PR TITLE
alerts list added detail of "Check monitor"

### DIFF
--- a/alerts/command.go
+++ b/alerts/command.go
@@ -164,11 +164,36 @@ func joinMonitorsAndHosts(ctx context.Context, client mackerelclient.Client, ale
 
 var statusRegexp = regexp.MustCompile("^[2-5][0-9][0-9]$")
 
-type formatJoinedAlertClient interface {
+type clientFindCheckMonitorContext interface {
 	FindCheckMonitorContext(ctx context.Context, monitorID string) (*mackerel.FindCheckMonitorResp, error)
 }
 
-func formatJoinedAlert(ctx context.Context, client formatJoinedAlertClient, alertSet *alertSet, colorize bool) string {
+type checkMonitorsWithCache struct {
+	cache  map[string]*mackerel.FindCheckMonitorResp
+	client clientFindCheckMonitorContext
+}
+
+func checkMonitorsWithCacheNew(client clientFindCheckMonitorContext) *checkMonitorsWithCache {
+	return &checkMonitorsWithCache{
+		cache:  make(map[string]*mackerel.FindCheckMonitorResp),
+		client: client,
+	}
+}
+
+func (c *checkMonitorsWithCache) FindCheckMonitorContext(ctx context.Context, monitorID string) (*mackerel.FindCheckMonitorResp, error) {
+	if monitor, ok := c.cache[monitorID]; ok {
+		return monitor, nil
+	}
+
+	monitor, err := c.client.FindCheckMonitorContext(ctx, monitorID)
+	if err != nil {
+		return nil, err
+	}
+	c.cache[monitorID] = monitor
+	return monitor, nil
+}
+
+func formatJoinedAlert(ctx context.Context, client clientFindCheckMonitorContext, alertSet *alertSet, colorize bool) string {
 	const layout = "2006-01-02 15:04:05"
 
 	host := alertSet.Host
@@ -333,6 +358,8 @@ func doAlertsList(ctx context.Context, c *cli.Command) error {
 	alerts, err := fetchAlerts(ctx, client, withClosed, getAlertsLimit(c, withClosed))
 	logger.DieIf(err)
 
+	cmClient := checkMonitorsWithCacheNew(client)
+
 	joinedAlerts := joinMonitorsAndHosts(ctx, client, alerts)
 	for _, joinAlert := range joinedAlerts {
 		if len(filterServices) > 0 {
@@ -367,7 +394,7 @@ func doAlertsList(ctx context.Context, c *cli.Command) error {
 				continue
 			}
 		}
-		fmt.Fprintln(color.Output, formatJoinedAlert(ctx, client, joinAlert, c.Bool("color")))
+		fmt.Fprintln(color.Output, formatJoinedAlert(ctx, cmClient, joinAlert, c.Bool("color")))
 	}
 	return nil
 }

--- a/alerts/command.go
+++ b/alerts/command.go
@@ -164,7 +164,11 @@ func joinMonitorsAndHosts(ctx context.Context, client mackerelclient.Client, ale
 
 var statusRegexp = regexp.MustCompile("^[2-5][0-9][0-9]$")
 
-func formatJoinedAlert(alertSet *alertSet, colorize bool) string {
+type formatJoinedAlertClient interface {
+	FindCheckMonitorContext(ctx context.Context, monitorID string) (*mackerel.FindCheckMonitorResp, error)
+}
+
+func formatJoinedAlert(ctx context.Context, client formatJoinedAlertClient, alertSet *alertSet, colorize bool) string {
 	const layout = "2006-01-02 15:04:05"
 
 	host := alertSet.Host
@@ -257,9 +261,13 @@ func formatJoinedAlert(alertSet *alertSet, colorize bool) string {
 			monitorMsg = monitor.MonitorName() + " " + monitorMsg
 		}
 	}
-	// If alert is caused by check monitoring, take monitorMsg from alert.message
+	// If alert is caused by check monitoring, take and overwrite monitorMsg from alert.message
 	if alert.Type == "check" {
-		monitorMsg = formatCheckMessage(alert.Message)
+		var checkMonitorName string
+		if cm, err := client.FindCheckMonitorContext(ctx, alert.MonitorID); err == nil && cm != nil {
+			checkMonitorName = cm.Check.Name
+		}
+		monitorMsg = formatCheckMessage(alert.Message, checkMonitorName)
 	}
 
 	statusMsg := alert.Status
@@ -288,7 +296,7 @@ func formatExpressionOneline(expr string) string {
 	return expressionParenthesisReplacer.Replace(expr)
 }
 
-func formatCheckMessage(msg string) string {
+func formatCheckMessage(msg string, checkMonitorName string) string {
 	truncated := false
 	if index := strings.IndexAny(msg, "\n\r"); index != -1 {
 		msg = msg[0:index]
@@ -300,6 +308,9 @@ func formatCheckMessage(msg string) string {
 	}
 	if truncated {
 		msg += "..."
+	}
+	if checkMonitorName != "" {
+		return checkMonitorName + " " + msg
 	}
 	return msg
 }
@@ -356,7 +367,7 @@ func doAlertsList(ctx context.Context, c *cli.Command) error {
 				continue
 			}
 		}
-		fmt.Fprintln(color.Output, formatJoinedAlert(joinAlert, c.Bool("color")))
+		fmt.Fprintln(color.Output, formatJoinedAlert(ctx, client, joinAlert, c.Bool("color")))
 	}
 	return nil
 }

--- a/alerts/command_test.go
+++ b/alerts/command_test.go
@@ -1,6 +1,7 @@
 package alerts
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -13,6 +14,18 @@ func pfloat64(x float64) *float64 {
 
 func puint64(x uint64) *uint64 {
 	return &x
+}
+
+type dummyClient struct {
+}
+
+func (d *dummyClient) FindCheckMonitorContext(ctx context.Context, monitorID string) (*mackerel.FindCheckMonitorResp, error) {
+	return &mackerel.FindCheckMonitorResp{
+		Check: mackerel.CheckMonitor{
+			ID:   "5rXR3",
+			Name: "foo-check-script",
+		},
+	}, nil
 }
 
 func TestFormatJoinedAlert(t *testing.T) {
@@ -75,7 +88,7 @@ func TestFormatJoinedAlert(t *testing.T) {
 				&mackerel.Host{ID: "3XYyG", Name: "app.example.com", Roles: mackerel.Roles{"foo": {"bar", "baz"}}, Status: "working"},
 				nil,
 			},
-			"2tZhm 1970-01-01 00:08:20 WARNING Short check monitoring description app.example.com working [foo:bar,baz]",
+			"2tZhm 1970-01-01 00:08:20 WARNING foo-check-script Short check monitoring description app.example.com working [foo:bar,baz]",
 		},
 		{
 			&alertSet{
@@ -83,7 +96,7 @@ func TestFormatJoinedAlert(t *testing.T) {
 				&mackerel.Host{ID: "3XYyG", Name: "app.example.com", Roles: mackerel.Roles{"foo": {"bar", "baz"}}, Status: "working"},
 				nil,
 			},
-			"2tZhm 1970-01-01 00:08:20 WARNING description with... app.example.com working [foo:bar,baz]",
+			"2tZhm 1970-01-01 00:08:20 WARNING foo-check-script description with... app.example.com working [foo:bar,baz]",
 		},
 		{
 			&alertSet{
@@ -91,7 +104,7 @@ func TestFormatJoinedAlert(t *testing.T) {
 				&mackerel.Host{ID: "3XYyG", Name: "app.example.com", Roles: mackerel.Roles{"foo": {"bar", "baz"}}, Status: "working"},
 				nil,
 			},
-			"2tZhm 1970-01-01 00:08:20 WARNING long long long long long long long long long long long long long long long long long long long そして長い... app.example.com working [foo:bar,baz]",
+			"2tZhm 1970-01-01 00:08:20 WARNING foo-check-script long long long long long long long long long long long long long long long long long long long そして長い... app.example.com working [foo:bar,baz]",
 		},
 		{
 			&alertSet{
@@ -104,7 +117,7 @@ func TestFormatJoinedAlert(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		str := formatJoinedAlert(testCase.alertSet, false)
+		str := formatJoinedAlert(t.Context(), &dummyClient{}, testCase.alertSet, false)
 		if str != testCase.want {
 			t.Errorf("should be '%s' but got '%s'", testCase.want, str)
 		}

--- a/alerts/command_test.go
+++ b/alerts/command_test.go
@@ -2,6 +2,7 @@ package alerts
 
 import (
 	"context"
+	"reflect"
 	"testing"
 	"time"
 
@@ -17,9 +18,11 @@ func puint64(x uint64) *uint64 {
 }
 
 type dummyClient struct {
+	called int
 }
 
 func (d *dummyClient) FindCheckMonitorContext(ctx context.Context, monitorID string) (*mackerel.FindCheckMonitorResp, error) {
+	d.called++
 	return &mackerel.FindCheckMonitorResp{
 		Check: mackerel.CheckMonitor{
 			ID:   "5rXR3",
@@ -121,5 +124,25 @@ func TestFormatJoinedAlert(t *testing.T) {
 		if str != testCase.want {
 			t.Errorf("should be '%s' but got '%s'", testCase.want, str)
 		}
+	}
+}
+
+func Test_checkMonitorsWithCache(t *testing.T) {
+	d := &dummyClient{}
+	client := checkMonitorsWithCacheNew(d)
+	resp, err := client.FindCheckMonitorContext(t.Context(), "5rXR3")
+	if err != nil {
+		t.Error("error occured")
+	}
+
+	got := mackerel.CheckMonitor{ID: "5rXR3", Name: "foo-check-script"}
+	if !reflect.DeepEqual(resp.Check, got) {
+		t.Errorf("should be '%s' but got '%s'", resp.Check, got)
+	}
+	if _, err := client.FindCheckMonitorContext(t.Context(), "5rXR3"); err != nil {
+		t.Error("error occured")
+	}
+	if d.called != 1 {
+		t.Error("d.called != 1")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jpillora/backoff v1.0.0
 	github.com/mackerelio/checkers v0.2.1
 	github.com/mackerelio/mackerel-agent v0.87.0
-	github.com/mackerelio/mackerel-client-go v0.45.0
+	github.com/mackerelio/mackerel-client-go v0.45.1
 	github.com/mholt/archives v0.1.5
 	github.com/motemen/go-colorine v0.0.0-20180816141035-45d19169413a
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,8 @@ github.com/mackerelio/golib v1.2.2 h1:fQfW1o2KvPyIsAH/7+M2J0gpf2jLu+NyYpDCN79zxW
 github.com/mackerelio/golib v1.2.2/go.mod h1:itcSOfrsT5XvkzflFPebT43RrliaKDz2T6YGYt3jclw=
 github.com/mackerelio/mackerel-agent v0.87.0 h1:XIfbSAjG6kAmTSWcY3yk6vhA043/x7VR4lBh/3DOdGo=
 github.com/mackerelio/mackerel-agent v0.87.0/go.mod h1:/TzlgQl6uB9LUs6pHIScyrGtECJcuEjnEQHAlLxfMR8=
-github.com/mackerelio/mackerel-client-go v0.45.0 h1:Tw+eSr8AkSoM7wHtTwF/hRbi7/Ib8m+B3NsxnI0xV5I=
-github.com/mackerelio/mackerel-client-go v0.45.0/go.mod h1:idAyt+GkVknFIupw1Y3vW1v5fJuqz2eiQrWU/oHOrEM=
+github.com/mackerelio/mackerel-client-go v0.45.1 h1:NuyNOoUpWkU7Nv+BIoCo3uX3QQeLV+89oiAdD1gohuE=
+github.com/mackerelio/mackerel-client-go v0.45.1/go.mod h1:idAyt+GkVknFIupw1Y3vW1v5fJuqz2eiQrWU/oHOrEM=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/mackerelclient/client.go
+++ b/mackerelclient/client.go
@@ -26,6 +26,7 @@ type Client interface {
 	FindAlertsByNextIDContext(ctx context.Context, nextID string) (*mackerel.AlertsResp, error)
 	CloseAlertContext(ctx context.Context, alertID string, reason string) (*mackerel.Alert, error)
 	FindAlertLogsContext(ctx context.Context, alertId string, params *mackerel.FindAlertLogsParam) (*mackerel.FindAlertLogsResp, error)
+	FindCheckMonitorContext(ctx context.Context, monitorID string) (*mackerel.FindCheckMonitorResp, error)
 	FindMonitorsContext(ctx context.Context) ([]mackerel.Monitor, error)
 	CreateGraphAnnotationContext(ctx context.Context, annotation *mackerel.GraphAnnotation) (*mackerel.GraphAnnotation, error)
 	FindGraphAnnotationsContext(ctx context.Context, service string, from int64, to int64) ([]*mackerel.GraphAnnotation, error)

--- a/mackerelclient/mock_client.go
+++ b/mackerelclient/mock_client.go
@@ -294,3 +294,6 @@ func (c *MockClient) DeleteMonitorContext(ctx context.Context, monitorID string)
 func (c *MockClient) UpdateMonitorContext(ctx context.Context, monitorID string, param mackerel.Monitor) (mackerel.Monitor, error) {
 	return nil, errNotImplemented
 }
+func (c *MockClient) FindCheckMonitorContext(ctx context.Context, monitorID string) (*mackerel.FindCheckMonitorResp, error) {
+	return nil, errNotImplemented
+}


### PR DESCRIPTION
`alerts list` added detail of "Check monitor"
used https://mackerel.io/api-docs/entry/check-monitoring#list 
