### PR TITLE
Fix data race in mkr wrap merging command output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/urfave/cli/v3 v3.10.1
 	github.com/yudai/gojsondiff v1.0.0
 	golang.org/x/oauth2 v0.36.0
-	golang.org/x/sync v0.22.0
 	golang.org/x/text v0.40.0
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -67,6 +66,7 @@ require (
 	github.com/yudai/pp v2.0.1+incompatible // indirect
 	go4.org v0.0.0-20230225012048-214862532bf5 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
+	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect

--- a/wrap/testdata/interleave.go
+++ b/wrap/testdata/interleave.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	for i := range 100 {
+		fmt.Fprintln(os.Stdout, "out", i)
+		fmt.Fprintln(os.Stderr, "err", i)
+	}
+}

--- a/wrap/wrap.go
+++ b/wrap/wrap.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"sync"
 	"time"
 
 	"github.com/Songmu/retry"
@@ -14,7 +15,6 @@ import (
 	"github.com/mackerelio/mackerel-client-go"
 	"github.com/mackerelio/mkr/logger"
 	"github.com/urfave/cli/v3"
-	"golang.org/x/sync/errgroup"
 )
 
 type wrap struct {
@@ -44,6 +44,17 @@ func (wr *wrap) run(ctx context.Context) error {
 	return nil
 }
 
+type syncBuffer struct {
+	bytes.Buffer
+	mu sync.Mutex
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.Buffer.Write(p)
+}
+
 func (wr *wrap) runCmd(ctx context.Context) *result {
 	cmd := exec.CommandContext(ctx, wr.cmd[0], wr.cmd[1:]...)
 	re := &result{
@@ -52,40 +63,11 @@ func (wr *wrap) runCmd(ctx context.Context) *result {
 		Note: wr.note,
 	}
 
-	stdoutPipe, err := cmd.StdoutPipe()
-	if err != nil {
-		return re.errorEnd("command invocation failed with follwing error: %s", err)
-	}
-	defer stdoutPipe.Close()
+	bufMerged := &syncBuffer{}
+	cmd.Stdout = io.MultiWriter(wr.outStream, bufMerged)
+	cmd.Stderr = io.MultiWriter(wr.errStream, bufMerged)
 
-	stderrPipe, err := cmd.StderrPipe()
-	if err != nil {
-		return re.errorEnd("command invocation failed with follwing error: %s", err)
-	}
-	defer stderrPipe.Close()
-
-	bufMerged := &bytes.Buffer{}
-	stdoutPipe2 := io.TeeReader(stdoutPipe, bufMerged)
-	stderrPipe2 := io.TeeReader(stderrPipe, bufMerged)
-
-	err = cmd.Start()
-	if err != nil {
-		return re.errorEnd("command invocation failed with follwing error: %s", err)
-	}
-	eg := &errgroup.Group{}
-
-	eg.Go(func() error {
-		defer stdoutPipe.Close()
-		_, err := io.Copy(wr.outStream, stdoutPipe2)
-		return err
-	})
-	eg.Go(func() error {
-		defer stderrPipe.Close()
-		_, err := io.Copy(wr.errStream, stderrPipe2)
-		return err
-	})
-	err = eg.Wait()
-	if err != nil {
+	if err := cmd.Start(); err != nil {
 		return re.errorEnd("command invocation failed with follwing error: %s", err)
 	}
 

--- a/wrap/wrap_test.go
+++ b/wrap/wrap_test.go
@@ -1,8 +1,10 @@
 package wrap
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -290,6 +292,62 @@ func Test_truncate(t *testing.T) {
 		if len([]rune(got)) > tc.limit {
 			t.Errorf("length of truncate(%q, %d, %q) should not exceed %d but got: %d",
 				tc.src, tc.limit, tc.sep, tc.limit, len([]rune(got)))
+		}
+	}
+}
+
+// TestRunCmd_Output checks that stdout and stderr of the command are passed
+// through to their respective streams, and that both are merged into the
+// output of the report. Running it under -race also detects unsynchronized
+// access to the merged buffer.
+func TestRunCmd_Output(t *testing.T) {
+	const lines = 100
+	var bufOut, bufErr bytes.Buffer
+	wr := &wrap{
+		cmd:       []string{"go", "run", "testdata/interleave.go"},
+		outStream: &bufOut,
+		errStream: &bufErr,
+	}
+
+	re := wr.runCmd(t.Context())
+
+	if re.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0 (msg: %s)", re.ExitCode, re.Msg)
+	}
+
+	for _, tc := range []struct {
+		name, got, prefix, unexpected string
+	}{
+		{"stdout", bufOut.String(), "out ", "err "},
+		{"stderr", bufErr.String(), "err ", "out "},
+	} {
+		if strings.Contains(tc.got, tc.unexpected) {
+			t.Errorf("%s should not contain %q", tc.name, tc.unexpected)
+		}
+		got := strings.Split(strings.TrimSuffix(tc.got, "\n"), "\n")
+		if len(got) != lines {
+			t.Errorf("%s has %d lines, want %d", tc.name, len(got), lines)
+			continue
+		}
+		for i, line := range got {
+			if want := fmt.Sprintf("%s%d", tc.prefix, i); line != want {
+				t.Errorf("%s line %d is %q, want %q", tc.name, i, line, want)
+				break
+			}
+		}
+	}
+
+	if got, want := strings.Count(re.Output, "\n"), lines*2; got != want {
+		t.Errorf("merged output has %d lines, want %d", got, want)
+	}
+	for i := range lines {
+		for _, want := range []string{
+			fmt.Sprintf("out %d\n", i),
+			fmt.Sprintf("err %d\n", i),
+		} {
+			if !strings.Contains(re.Output, want) {
+				t.Errorf("merged output does not contain %q", want)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Problem

`mkr wrap` merged the wrapped command's stdout and stderr into one
`bytes.Buffer` via two `io.TeeReader`s, each drained by its own goroutine.
`bytes.Buffer` is not safe for concurrent use.

This is not only a race-detector complaint - it loses data. With 100 lines
written to each stream, the report contained ~190 of the 200 lines, and the
losses clustered at the start of stderr. That buffer becomes the alert body
posted to Mackerel, so `mkr wrap --detail` has been reporting failing cron
jobs with parts of their stderr missing.

## Fix

`os/exec` already copies to `cmd.Stdout`/`cmd.Stderr`, so the manual pipe
plumbing was unnecessary:

- dropped `StdoutPipe`/`StderrPipe`, both `TeeReader`s, the `errgroup` and
  its two goroutines
- merged buffer is now guarded by a `sync.Mutex`, fixing the race problem

Two latent bugs went away with the old code:

- the `eg.Wait()` error path returned before `cmd.Wait()`, leaving the child
  unreaped and its fds open
- each pipe had a `defer Close()` at the top *and* one inside its goroutine,
  on top of the close `cmd.Wait()` already does

Behavior is unchanged: stdout still goes to stdout, stderr to stderr, and
both to the report.
