### PR TITLE
Fix mkr alerts list dropping alerts when multiple services are given

### DIFF
--- a/alerts/command.go
+++ b/alerts/command.go
@@ -376,7 +376,7 @@ func doAlertsList(ctx context.Context, c *cli.Command) error {
 					} else if m, ok := joinAlert.Monitor.(*mackerel.MonitorExternalHTTP); ok {
 						service = m.Service
 					}
-					found = service == filterService
+					found = found || service == filterService
 				}
 			}
 			if !found {


### PR DESCRIPTION
## Problem

`mkr alerts list` accepts `--service` multiple times, but for alerts that
aren't attached to a host it only honored the last one.

In the `joinAlert.Host == nil` branch, `found` was assigned rather than
accumulated, so each iteration of the filter loop discarded the previous
result:

```go
found = service == filterService
```

`mkr alerts list -s A -s B` therefore hid every service metric and
external HTTP alert on service A: the first iteration set
`found = true`, the second overwrote it with A == B → false.

## Fix

```go
found = found || service == filterService
```
