### PR TITLE
Follow redirects for repository transfers in getTagFromReleasesURL

### DIFF
--- a/plugin/install_target.go
+++ b/plugin/install_target.go
@@ -173,34 +173,56 @@ func (it *installTarget) getTagFromReleasesURL(ctx context.Context, owner, repo 
 		},
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodHead, latestURL, nil)
-	if err != nil {
-		return "", err
-	}
-	req.Header.Set("User-Agent", userAgent)
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", err
-	}
-	io.Copy(io.Discard, resp.Body) //nolint:errcheck
-	defer resp.Body.Close()
+	for i := 0; i < 5; i++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodHead, latestURL, nil)
+		if err != nil {
+			return "", err
+		}
+		req.Header.Set("User-Agent", userAgent)
+		resp, err := client.Do(req)
+		if err != nil {
+			return "", err
+		}
+		io.Copy(io.Discard, resp.Body) //nolint:errcheck
+		resp.Body.Close()
 
-	loc := resp.Header.Get("Location")
-	if loc == "" {
-		return "", fmt.Errorf("no Location header found (status=%d)", resp.StatusCode)
+		loc := resp.Header.Get("Location")
+		if loc == "" {
+			return "", fmt.Errorf("no Location header found (status=%d)", resp.StatusCode)
+		}
+
+		u, err := resp.Request.URL.Parse(loc)
+		if err != nil {
+			return "", err
+		}
+
+		// Follow redirect caused by repository transfer.
+		// GitHub redirects /owner/repo/releases/latest to the new repository's latest URL.
+		if it.isReleasesLatestURL(u) {
+			latestURL = u.String()
+			continue
+		}
+
+		tag, err := extractTagFromReleasesURL(u)
+		if err != nil {
+			return "", err
+		}
+		it.releaseTag = tag
+		return it.releaseTag, nil
 	}
 
-	u, err := resp.Request.URL.Parse(loc)
-	if err != nil {
-		return "", err
-	}
+	return "", fmt.Errorf("too many redirects")
+}
 
-	tag, err := extractTagFromReleasesURL(u)
-	if err != nil {
-		return "", err
+func (it *installTarget) isReleasesLatestURL(u *url.URL) bool {
+	if strings.Index(u.String(), it.getGithubURL()) != 0 {
+		return false
 	}
-	it.releaseTag = tag
-	return it.releaseTag, nil
+	segments := strings.Split(strings.Trim(u.EscapedPath(), "/"), "/")
+	if len(segments) < 4 {
+		return false
+	}
+	return segments[len(segments)-2] == "releases" && segments[len(segments)-1] == "latest"
 }
 
 func extractTagFromReleasesURL(u *url.URL) (string, error) {

--- a/plugin/install_target_test.go
+++ b/plugin/install_target_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"runtime"
 	"testing"
 
@@ -330,6 +331,37 @@ func TestInstallTargetGetOwnerAndRepo(t *testing.T) {
 	}
 }
 
+func TestIsReleasesLatestURL(t *testing.T) {
+	testCases := []struct {
+		Name   string
+		Input  string
+		Output bool
+	}{
+		{
+			Name:   "Valid releases/latest URL",
+			Input:  "https://github.com/owner/repo/releases/latest",
+			Output: true,
+		},
+		{
+			Name:   "Invalid releases/latest URL",
+			Input:  "https://github.com/owner/repo/releases/tag/v1.2.3",
+			Output: false,
+		},
+		{
+			Name:   "Invalid URL",
+			Input:  "https://example.com/owner/repo/releases/latest",
+			Output: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			it := &installTarget{githubURL: "https://github.com"}
+			u, _ := url.Parse(tc.Input)
+			assert.Equal(t, tc.Output, it.isReleasesLatestURL(u))
+		})
+	}
+}
+
 func TestInstallTargetgetTagFromReleasesURL(t *testing.T) {
 
 	mux := http.NewServeMux()
@@ -343,6 +375,19 @@ func TestInstallTargetgetTagFromReleasesURL(t *testing.T) {
 	})
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
+
+	mux.HandleFunc("/old-owner/repo3/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", fmt.Sprintf("%s/new-owner/repo3/releases/latest", ts.URL))
+		w.WriteHeader(http.StatusMovedPermanently)
+	})
+	mux.HandleFunc("/new-owner/repo3/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", "https://github.com/new-owner/repo3/releases/tag/v1.0.0")
+		w.WriteHeader(http.StatusMovedPermanently)
+	})
+	mux.HandleFunc("/owner3/repo4/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", fmt.Sprintf("%s/owner3/repo4/releases/latest", ts.URL))
+		w.WriteHeader(http.StatusMovedPermanently)
+	})
 
 	{
 		// it already has releaseTag
@@ -373,6 +418,22 @@ func TestInstallTargetgetTagFromReleasesURL(t *testing.T) {
 		it := &installTarget{githubURL: ts.URL}
 		releaseTag, err := it.getTagFromReleasesURL(t.Context(), "owner2", "repo2")
 		assert.Error(t, err, "Returns err if the repository is not found")
+		assert.Equal(t, "", releaseTag, "Returns empty string")
+	}
+
+	{
+		// Repository transfer: follow redirect to new repository's releases/latest
+		it := &installTarget{githubURL: ts.URL}
+		releaseTag, err := it.getTagFromReleasesURL(t.Context(), "old-owner", "repo3")
+		assert.NoError(t, err, "getReleaseTag is successful")
+		assert.Equal(t, "v1.0.0", releaseTag, "releaseTag is fetched from transferred repository")
+	}
+
+	{
+		// Too many redirects
+		it := &installTarget{githubURL: ts.URL}
+		releaseTag, err := it.getTagFromReleasesURL(t.Context(), "owner3", "repo4")
+		assert.Error(t, err, "Returns err if too many redirects")
 		assert.Equal(t, "", releaseTag, "Returns empty string")
 	}
 }


### PR DESCRIPTION
Enhance https://github.com/mackerelio/mkr/pull/714
Follow redirects for repository transfers in getTagFromReleasesURL

For example
https://github.com/kazeburo/mackerel-plugin-axslog/releases/latest
↓ redirect
https://github.com/monitoring-forge/mackerel-plugin-axslog/releases/latest
↓ redirect
https://github.com/monitoring-forge/mackerel-plugin-axslog/releases/tag/v0.4.13
