### PR TITLE
Validate the range of the limit flag of the alerts commands

### DIFF
--- a/alerts/command.go
+++ b/alerts/command.go
@@ -39,6 +39,7 @@ var Command = &cli.Command{
 			Aliases: []string{"l"},
 			Value:   defaultAlertsLimit,
 			Usage:   fmt.Sprintf("Set the number of alerts to display. Default is set to %d when -with-closed is set, otherwise all the open alerts are displayed.", defaultAlertsLimit),
+			Action:  validateLimitFlag,
 		},
 		jq.CommandLineFlag,
 	},
@@ -78,6 +79,7 @@ var Command = &cli.Command{
 					Aliases: []string{"l"},
 					Value:   defaultAlertsLimit,
 					Usage:   fmt.Sprintf("Set the number of alerts to display. Default is set to %d when -with-closed is set, otherwise all the open alerts are displayed.", defaultAlertsLimit),
+					Action:  validateLimitFlag,
 				},
 			},
 		},
@@ -117,6 +119,7 @@ var Command = &cli.Command{
 					Aliases: []string{"l"},
 					Value:   defaultAlertLogsLimit,
 					Usage:   "Set the number of alert logs to display",
+					Action:  validateLimitFlag,
 				},
 				jq.CommandLineFlag,
 			},
@@ -126,6 +129,22 @@ var Command = &cli.Command{
 
 const defaultAlertsLimit int = 100
 const defaultAlertLogsLimit int = 100
+
+// maxAlertsLimit is the upper bound of the limit flags. The API returns at most
+// 100 items per request, so this limit already requires 10,000 requests, and no
+// larger value is of practical use. Note that the limit is used as the capacity
+// of a slice, which panics on a too large value, especially on 32-bit systems.
+const maxAlertsLimit int = 1_000_000
+
+func validateLimitFlag(_ context.Context, _ *cli.Command, limit int) error {
+	if limit < 0 {
+		return errors.New("limit should not be negative")
+	}
+	if limit > maxAlertsLimit {
+		return fmt.Errorf("limit should not exceed %d", maxAlertsLimit)
+	}
+	return nil
+}
 
 type alertSet struct {
 	Alert   *mackerel.Alert
@@ -411,9 +430,6 @@ func getAlertsLimit(c *cli.Command, withClosed bool) int {
 }
 
 func fetchAlerts(ctx context.Context, client mackerelclient.Client, withClosed bool, limit int) ([]*mackerel.Alert, error) {
-	if limit < 0 {
-		return nil, errors.New("limit should not be negative")
-	}
 	var resp *mackerel.AlertsResp
 	var err error
 	if withClosed {


### PR DESCRIPTION
## Problem

`mkr alerts logs` panics on a negative `--limit`:

```
 $ mkr alerts logs <alertId> --limit=-1
panic: runtime error: makeslice: cap out of range
```

`findAlertLogs` preallocates with the raw flag value and `makeslice` rejects a
negative capacity. A value too large to allocate panics the same way.
`fetchAlerts` already guarded `limit < 0`, but `findAlertLogs` never got the
same check.

## Fix

Validate both bounds in a `validateLimitFlag` action shared by the `limit`
flags of `alerts`, `alerts list` and `alerts logs`, and drop the now
redundant guard in `fetchAlerts` - `getAlertsLimit` only ever yields a
validated flag value, `defaultAlertsLimit`, or the `math.MaxInt32` sentinel,
so nothing else reaches it.

## Why 1,000,000

The API returns at most 100 items per request, so reaching this limit already
takes 10,000 requests - no larger value is of practical use. It also keeps
the preallocation at 4 MB on the 32-bit builds (`386`, `arm` per the
Makefile), where `int` is 32 bits: there `limit > math.MaxInt32` can never be
true, yet `make([]*AlertLog, 0, 2e9)` needs 8 GB of a 4 GB address space.
An upper bound derived from `math.MaxInt32` would have been dead code exactly
on the platforms that need it most.

## Notes

No regression test is included, so nothing prevents this from coming back -
happy to add one if you want it here rather than as a follow-up.
