### PR TITLE
Fix the release URL validation of mkr plugin install

### DIFF
--- a/plugin/install_target.go
+++ b/plugin/install_target.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"path"
 	"regexp"
 	"runtime"
 	"strings"
@@ -214,32 +213,27 @@ func (it *installTarget) getTagFromReleasesURL(ctx context.Context, owner, repo 
 	return "", fmt.Errorf("too many redirects")
 }
 
+func pathSegments(u *url.URL) []string {
+	return strings.FieldsFunc(u.EscapedPath(), func(r rune) bool { return r == '/' })
+}
+
 func (it *installTarget) isReleasesLatestURL(u *url.URL) bool {
-	if strings.Index(u.String(), it.getGithubURL()) != 0 {
+	base, err := url.Parse(it.getGithubURL())
+	if err != nil || u.Scheme != base.Scheme || u.Host != base.Host {
 		return false
 	}
-	segments := strings.Split(strings.Trim(u.EscapedPath(), "/"), "/")
-	if len(segments) < 4 {
-		return false
-	}
-	return segments[len(segments)-2] == "releases" && segments[len(segments)-1] == "latest"
+	// /<owner>/<repo>/releases/latest
+	segments := pathSegments(u)
+	return len(segments) == 4 && segments[2] == "releases" && segments[3] == "latest"
 }
 
 func extractTagFromReleasesURL(u *url.URL) (string, error) {
 	// /<owner>/<repo>/releases/tag/v1.2.3
-	segments := strings.Split(strings.Trim(u.EscapedPath(), "/"), "/")
-	for i := 0; i < len(segments)-1; i++ {
-		if segments[i] == "releases" && i+1 < len(segments) && segments[i+1] == "tag" {
-			// Ends with a tag
-			raw := path.Base(u.EscapedPath())
-			tag, err := url.PathUnescape(raw)
-			if err != nil {
-				return "", err
-			}
-			return tag, nil
-		}
+	segments := pathSegments(u)
+	if len(segments) != 5 || segments[2] != "releases" || segments[3] != "tag" {
+		return "", fmt.Errorf("not a releases/tag URL")
 	}
-	return "", fmt.Errorf("not a releases/tag URL")
+	return url.PathUnescape(segments[4])
 }
 
 func (it *installTarget) getRawGithubURL() string {

--- a/plugin/install_target_test.go
+++ b/plugin/install_target_test.go
@@ -352,12 +352,91 @@ func TestIsReleasesLatestURL(t *testing.T) {
 			Input:  "https://example.com/owner/repo/releases/latest",
 			Output: false,
 		},
+		{
+			Name:   "Invalid host with the github URL as its prefix",
+			Input:  "https://github.com.example.com/owner/repo/releases/latest",
+			Output: false,
+		},
+		{
+			Name:   "Different scheme",
+			Input:  "http://github.com/owner/repo/releases/latest",
+			Output: false,
+		},
+		{
+			Name:   "Extra segment before the owner",
+			Input:  "https://github.com/extra/owner/repo/releases/latest",
+			Output: false,
+		},
+		{
+			Name:   "Path ending with a slash",
+			Input:  "https://github.com/owner/repo/releases/latest/",
+			Output: true,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			it := &installTarget{githubURL: "https://github.com"}
 			u, _ := url.Parse(tc.Input)
 			assert.Equal(t, tc.Output, it.isReleasesLatestURL(u))
+		})
+	}
+}
+
+func TestExtractTagFromReleasesURL(t *testing.T) {
+	testCases := []struct {
+		Name   string
+		Input  string
+		Output string
+		Error  bool
+	}{
+		{
+			Name:   "Valid releases/tag URL",
+			Input:  "https://github.com/owner/repo/releases/tag/v1.2.3",
+			Output: "v1.2.3",
+		},
+		{
+			Name:   "Release tag containing an escaped slash",
+			Input:  "https://github.com/owner/repo/releases/tag/release%2Fv0.5.1",
+			Output: "release/v0.5.1",
+		},
+		{
+			Name:   "Path ending with a slash",
+			Input:  "https://github.com/owner/repo/releases/tag/v1.2.3/",
+			Output: "v1.2.3",
+		},
+		{
+			Name:  "Extra segment after the release tag",
+			Input: "https://github.com/owner/repo/releases/tag/v1.2.3/extra",
+			Error: true,
+		},
+		{
+			Name:  "releases/tag in an unexpected position",
+			Input: "https://github.com/releases/tag/owner/repo",
+			Error: true,
+		},
+		{
+			Name:  "releases/latest URL",
+			Input: "https://github.com/owner/repo/releases/latest",
+			Error: true,
+		},
+		{
+			Name:  "Too few segments",
+			Input: "https://github.com/owner/repo",
+			Error: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			u, err := url.Parse(tc.Input)
+			assert.NoError(t, err)
+			tag, err := extractTagFromReleasesURL(u)
+			if tc.Error {
+				assert.Error(t, err, "returns an error for an unexpected URL")
+				assert.Equal(t, "", tag, "returns an empty string")
+				return
+			}
+			assert.NoError(t, err, "extractTagFromReleasesURL is successful")
+			assert.Equal(t, tc.Output, tag, "release tag is extracted correctly")
 		})
 	}
 }


### PR DESCRIPTION
 ## Problem

Two checks on GitHub release URLs in `mkr plugin install` were looser than
intended.

1. The host check was a string prefix match.

```go
if strings.Index(u.String(), it.getGithubURL()) != 0 {
```

Any host whose URL merely starts with https://github.com passed - including
https://github.com.example.com/owner/repo/releases/latest, an
attacker-controlled subdomain. `getTagFromReleasesURL` uses this to decide
whether to follow a redirect, so mkr would chase a Location pointing off
GitHub and take a release tag from whatever answered. See https://github.com/mackerelio/mkr/pull/868#discussion_r3783614032.

2. The path checks ignored position.

`isReleasesLatestURL` only looked at the last two segments, and
`extractTagFromReleasesURL` searched for releases/tag anywhere in the path
and then returned the last segment regardless of where the match was - so
the match position was computed and discarded:

| path | old result |
| --- | --- |
| `/o/r/releases/tag/v1.2.3` | `"v1.2.3"` ✓ |
| `/o/r/releases/tag/v1.2.3/extra` | `"extra"` ✗ |
| `/releases/tag/o/r/anything` | `"anything"` ✗ |

A wrong tag is interpolated straight into the download URL, so the install
fails with http response not OK. code: 404 naming a tag the user never asked
for.

## Fix

- Parse the base URL and compare Scheme and Host instead of prefix-matching the URL string.
- Both URL shapes are fixed (`/<owner>/<repo>/releases/latest` and
  `/<owner>/<repo>/releases/tag/<tag>`), so check the segments positionally.
- Extract `pathSegments`, shared by both. It splits `EscapedPath()`, not
  `u.Path` - the decoded path turns `%2F` inside a tag into a real separator,
  which would split `release/v0.5.1` into two segments. `strings.FieldsFunc` also
  drops the phantom empty segment that `Split(Trim(...))` yields for an empty or
  root path.

An unrecognized URL now returns an error, which `makeDownloadURL` already
handles by falling back to `getReleaseTag`. Worth noting that fallback isn't
free - it spends a rate-limited GitHub API request, the very thing
`getTagFromReleasesURL` exists to avoid. It should stay rare, since GitHub's
real redirects are well-formed, and it beats a tag that 404s.

## Tests

New cases in `TestIsReleasesLatestURL` (prefix-matching host, different scheme,
extra leading segment, trailing slash) and a new `TestExtractTagFromReleasesURL`
table - that function previously had no direct coverage, which is how the loop's
wrong answers went unnoticed.

Each new case was mutation-tested: restoring the old implementations fails
exactly the cases that describe the bugs, and no others.

`TestInstallTargetgetTagFromReleasesURL` is unchanged and still passes,
including the repository-transfer case from #868 - those redirects use absolute
Locations on the test server, so scheme and host match. gofmt, go vet,
golangci-lint (0 issues), all packages green under `-race`.

ref: #714, #868
cc: @kazeburo
