### PR TITLE
Support the --jq option in mkr dashboards

### DIFF
--- a/dashboards/command.go
+++ b/dashboards/command.go
@@ -11,18 +11,23 @@ import (
 
 	"github.com/mackerelio/mackerel-client-go"
 	"github.com/mackerelio/mkr/format"
+	"github.com/mackerelio/mkr/jq"
 	"github.com/mackerelio/mkr/logger"
 	"github.com/mackerelio/mkr/mackerelclient"
 	"github.com/urfave/cli/v3"
 )
 
 var Command = &cli.Command{
-	Name:  "dashboards",
-	Usage: "Manipulate custom dashboards",
+	Name:      "dashboards",
+	Usage:     "Manipulate custom dashboards",
+	ArgsUsage: "[--jq <formula>]",
 	Description: `
     Manipulate custom dashboards. With no subcommand specified, this will show all dashboards. See https://mackerel.io/docs/entry/advanced/cli
 `,
 	Action: doListDashboards,
+	Flags: []cli.Flag{
+		jq.CommandLineFlag,
+	},
 	Commands: []*cli.Command{
 		{
 			Name:      "pull",
@@ -78,8 +83,7 @@ func doListDashboards(ctx context.Context, c *cli.Command) error {
 	dashboards, err := client.FindDashboardsContext(ctx)
 	logger.DieIf(err)
 
-	fmt.Println(format.JSONMarshalIndent(dashboards, "", "    "))
-	return nil
+	return format.PrettyPrintJSON(os.Stdout, dashboards, c.String("jq"))
 }
 
 func doPullDashboard(ctx context.Context, c *cli.Command) error {


### PR DESCRIPTION
`mkr dashboards` with no subcommand lists every dashboard as JSON - the same
shape as `mkr services`, `mkr channels`, `mkr org` and `mkr users`, all of
which accept `--jq`. It was the only one that didn't:

```
$ mkr dashboards --jq .
Incorrect Usage: flag provided but not defined: -jq
```

The cause is that it never went through the jq path at all. Every other list
command calls `format.PrettyPrintJSON(out, v, c.String("jq"))`; this one called
`fmt.Println(format.JSONMarshalIndent(dashboards, "", "    "))`.

## Change

- Register `jq.CommandLineFlag` on the command, with `ArgsUsage:
  "[--jq <formula>]"` to match its sibling commands.
- Replace the `fmt.Println(JSONMarshalIndent(...))` call with
  `format.PrettyPrintJSON(os.Stdout, dashboards, c.String("jq"))`.

Output without the flag is byte-identical: `PrettyPrintJSON` falls through to
the very same `JSONMarshalIndent(src, "", "    ")` when the query is empty, so
existing scripts are unaffected. Returning its error also stops the marshal
failure being swallowed - `JSONMarshalIndent` reports errors by calling
`logger.DieIf` (i.e. `os.Exit`) from inside a formatting helper.

`dashboards pull` writes files and `dashboards push` discards the API
response, so neither needs the flag.
